### PR TITLE
fix bug where HTTP headers across chunks would not be handled correctly

### DIFF
--- a/apps/src/bin/quiceh-server.rs
+++ b/apps/src/bin/quiceh-server.rs
@@ -49,12 +49,12 @@ use quiceh_apps::common::*;
 
 use quinn_udp::Transmit;
 
-use quinn_udp::UdpSocketState;
 use quinn_udp::RecvMeta;
+use quinn_udp::UdpSocketState;
 use quinn_udp::BATCH_SIZE;
 
-use std::io::IoSliceMut;
 use bytes::BytesMut;
+use std::io::IoSliceMut;
 
 use quiceh::bufpool;
 
@@ -191,6 +191,11 @@ fn main() {
     let mut continue_write = false;
 
     let local_addr = socket.local_addr().unwrap();
+    let mut iovs: [IoSliceMut; BATCH_SIZE] = {
+        let mut bufs = buf.chunks_mut(u16::MAX.into()).map(IoSliceMut::new);
+
+        std::array::from_fn(|_| bufs.next().expect("BATCH_SIZE elements"))
+    };
 
     loop {
         // Find the shorter timeout from all the active connections.
@@ -226,13 +231,6 @@ fn main() {
                 break 'read;
             }
 
-            let mut iovs: [IoSliceMut; BATCH_SIZE] = {
-                let mut bufs =
-                    buf.chunks_mut(u16::MAX.into()).map(IoSliceMut::new);
-
-                std::array::from_fn(|_| bufs.next().expect("BATCH_SIZE elements"))
-            };
-
             let len = match socket_state.recv(
                 (&socket_std).into(),
                 &mut iovs,
@@ -259,10 +257,12 @@ fn main() {
                 let mut data: BytesMut = buf[0..meta.len].into();
 
                 while !data.is_empty() {
-                    let mut pkt_buf_chunk = data.split_to(meta.stride.min(data.len()));
+                    let mut pkt_buf_chunk =
+                        data.split_to(meta.stride.min(data.len()));
                     let pkt_buf = &mut pkt_buf_chunk[..];
 
-                    if let Some(target_path) = conn_args.dump_packet_path.as_ref() {
+                    if let Some(target_path) = conn_args.dump_packet_path.as_ref()
+                    {
                         let path = format!("{target_path}/{pkt_count}.pkt");
 
                         if let Ok(f) = std::fs::File::create(path) {
@@ -290,7 +290,8 @@ fn main() {
 
                     let conn_id = if !cfg!(feature = "fuzzing") {
                         let conn_id = ring::hmac::sign(&conn_id_seed, &hdr.dcid);
-                        let conn_id = &conn_id.as_ref()[..quiceh::MAX_CONN_ID_LEN];
+                        let conn_id =
+                            &conn_id.as_ref()[..quiceh::MAX_CONN_ID_LEN];
                         conn_id.to_vec().into()
                     } else {
                         // When fuzzing use an all zero connection ID.
@@ -310,9 +311,10 @@ fn main() {
                         if !quiceh::version_is_supported(hdr.version) {
                             warn!("Doing version negotiation");
 
-                            let len =
-                                quiceh::negotiate_version(&hdr.scid, &hdr.dcid, &mut out)
-                                    .unwrap();
+                            let len = quiceh::negotiate_version(
+                                &hdr.scid, &hdr.dcid, &mut out,
+                            )
+                            .unwrap();
 
                             let out = &out[..len];
 
@@ -356,7 +358,8 @@ fn main() {
                                 let out = &out[..len];
 
                                 if let Err(e) = socket.send_to(out, from) {
-                                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                                    if e.kind() == std::io::ErrorKind::WouldBlock
+                                    {
                                         trace!("send() would block");
                                         break 'read;
                                     }
@@ -387,7 +390,10 @@ fn main() {
 
                         let scid = quiceh::ConnectionId::from_vec(scid.to_vec());
 
-                        debug!("New connection: dcid={:?} scid={:?}", hdr.dcid, scid);
+                        debug!(
+                            "New connection: dcid={:?} scid={:?}",
+                            hdr.dcid, scid
+                        );
 
                         #[allow(unused_mut)]
                         let mut conn = quiceh::accept_with_buf_factory(
@@ -410,7 +416,8 @@ fn main() {
                         {
                             if let Some(dir) = std::env::var_os("QLOGDIR") {
                                 let id = format!("{:?}", &scid);
-                                let writer = make_qlog_writer(&dir, "server", &id);
+                                let writer =
+                                    make_qlog_writer(&dir, "server", &id);
 
                                 conn.set_qlog(
                                     std::boxed::Box::new(writer),
@@ -460,7 +467,11 @@ fn main() {
                         Ok(v) => v,
 
                         Err(e) => {
-                            error!("{} recv failed: {:?}", client.conn.trace_id(), e);
+                            error!(
+                                "{} recv failed: {:?}",
+                                client.conn.trace_id(),
+                                e
+                            );
                             continue;
                         },
                     };
@@ -529,7 +540,11 @@ fn main() {
 
                         // Handle writable streams.
                         for stream_id in conn.writable() {
-                            http_conn.handle_writable(conn, partial_responses, stream_id);
+                            http_conn.handle_writable(
+                                conn,
+                                partial_responses,
+                                stream_id,
+                            );
                         }
 
                         if conn.version() == quiceh::PROTOCOL_VERSION_VREVERSO {
@@ -562,15 +577,21 @@ fn main() {
                     handle_path_events(client);
 
                     // See whether source Connection IDs have been retired.
-                    while let Some(retired_scid) = client.conn.retired_scid_next() {
+                    while let Some(retired_scid) = client.conn.retired_scid_next()
+                    {
                         info!("Retiring source CID {:?}", retired_scid);
                         clients_ids.remove(&retired_scid);
                     }
 
                     // Provides as many CIDs as possible.
                     while client.conn.scids_left() > 0 {
-                        let (scid, reset_token) = generate_cid_and_reset_token(&rng);
-                        if client.conn.new_scid(&scid, reset_token, false).is_err() {
+                        let (scid, reset_token) =
+                            generate_cid_and_reset_token(&rng);
+                        if client
+                            .conn
+                            .new_scid(&scid, reset_token, false)
+                            .is_err()
+                        {
                             break;
                         }
 

--- a/quiceh/src/h3/mod.rs
+++ b/quiceh/src/h3/mod.rs
@@ -2482,7 +2482,18 @@ impl Connection {
                         let b = stream.try_acquire_state_buffer(conn)?;
 
                         let varint = match stream.try_consume_varint_from_buf(b) {
-                            Ok(v) => v,
+                            Ok((varint, consumed)) => {
+                                if consumed == 0 {
+                                    varint.unwrap()
+                                } else {
+                                    conn.stream_consumed(stream_id, consumed)?;
+                                    if let Some(varint) = varint {
+                                        varint
+                                    } else {
+                                        return Err(Error::Done);
+                                    }
+                                }
+                            },
 
                             Err(_) => {
                                 return Err(Error::Done);
@@ -2492,6 +2503,7 @@ impl Connection {
                             conn,
                             stream.get_state_len(),
                         )?;
+
                         varint
                     } else {
                         stream.try_fill_buffer(conn)?;
@@ -2613,7 +2625,18 @@ impl Connection {
                         let b = stream.try_acquire_state_buffer(conn)?;
 
                         let varint = match stream.try_consume_varint_from_buf(b) {
-                            Ok(v) => v,
+                            Ok((varint, consumed)) => {
+                                if consumed == 0 {
+                                    varint.unwrap()
+                                } else {
+                                    conn.stream_consumed(stream_id, consumed)?;
+                                    if let Some(varint) = varint {
+                                        varint
+                                    } else {
+                                        return Err(Error::Done);
+                                    }
+                                }
+                            },
 
                             Err(_) => return Err(Error::Done),
                         };
@@ -2644,7 +2667,18 @@ impl Connection {
                         let b = stream.try_acquire_state_buffer(conn)?;
 
                         let varint = match stream.try_consume_varint_from_buf(b) {
-                            Ok(v) => v,
+                            Ok((varint, consumed)) => {
+                                if consumed == 0 {
+                                    varint.unwrap()
+                                } else {
+                                    conn.stream_consumed(stream_id, consumed)?;
+                                    if let Some(varint) = varint {
+                                        varint
+                                    } else {
+                                        return Err(Error::Done);
+                                    }
+                                }
+                            },
 
                             Err(_) => {
                                 return Err(Error::Done);
@@ -2698,7 +2732,18 @@ impl Connection {
                         let b = stream.try_acquire_state_buffer(conn)?;
 
                         let varint = match stream.try_consume_varint_from_buf(b) {
-                            Ok(v) => v,
+                            Ok((varint, consumed)) => {
+                                if consumed == 0 {
+                                    varint.unwrap()
+                                } else {
+                                    conn.stream_consumed(stream_id, consumed)?;
+                                    if let Some(varint) = varint {
+                                        varint
+                                    } else {
+                                        return Err(Error::Done);
+                                    }
+                                }
+                            },
 
                             Err(_) => {
                                 return Err(Error::Done);
@@ -4112,6 +4157,7 @@ mod tests {
                 assert_eq!(b.len(), body.len());
                 assert!(s.body_consumed_client(stream, body.len() - 1).is_ok());
                 assert!(s.body_consumed_client(stream, 1).is_ok());
+                assert_eq!(s.poll_client(), Ok((stream, Event::Data)));
             }
             // Read and consume body.len()-1
             let (b, _) = s.body_peek_client(stream).unwrap();
@@ -4121,6 +4167,92 @@ mod tests {
             let (b, _) = s.body_peek_client(stream).unwrap();
             assert_eq!(b.len(), 1);
             assert!(s.body_consumed_client(stream, 1).is_ok());
+            assert_eq!(s.poll_client(), Ok((4, Event::Finished)));
+        }
+    }
+
+    #[test]
+    /// Send a request with no body, respond with 2 DATA frames which the
+    /// second's header happens to be written across two StreamChunks whose
+    /// lengths are 100 bytes
+    fn request_no_body_resonses_two_data_with_header_across_stream_chunk() {
+        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+            let mut config = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+            config
+                .load_cert_chain_from_pem_file("examples/cert.crt")
+                .unwrap();
+            config
+                .load_priv_key_from_pem_file("examples/cert.key")
+                .unwrap();
+            config.set_application_protos(&[b"h3"]).unwrap();
+            config.set_initial_max_data(1500);
+            config.set_initial_max_stream_data_bidi_local(500);
+            config.set_initial_max_stream_data_bidi_remote(500);
+            config.set_initial_max_stream_data_uni(500);
+            config.set_initial_max_streams_bidi(5);
+            config.set_initial_max_streams_uni(5);
+            config.verify_peer(false);
+            config.grease(false);
+            config.set_ack_delay_exponent(8);
+            config.set_expected_chunklen_to_consume(100);
+
+            let h3_config = Config::new().expect("h3 config creation");
+            let mut s =
+                Session::<BufTestFactory>::with_configs(&mut config, &h3_config)
+                    .unwrap();
+            s.handshake().unwrap();
+            // Send 32 bytes -- client to server
+            let (stream, req) = s.send_request(true).unwrap();
+
+            let ev_headers = Event::Headers {
+                list: req,
+                has_body: false,
+            };
+
+            assert_eq!(s.poll_server(), Ok((stream, ev_headers)));
+            assert_eq!(s.poll_server(), Ok((stream, Event::Finished)));
+
+            let body = vec![42; 79];
+            // Send headers; 16 bytes
+            let resp = s.send_response(stream, false).unwrap();
+            // Send a first Data frame of 79 bytes. We'll be consume 98 bytes
+            // of the 100-bytes chunk.
+            s.send_body_server_zc(
+                stream,
+                BufTestFactory::buf_from_slice(&body),
+                false,
+            )
+            .unwrap();
+            // We need two bytes to encode the length of the data frame with 64 bytes
+            let body = vec![42; 64];
+            // The second Data frame should have its header across two StreamChunks.
+            s.send_body_server_zc(
+                stream,
+                BufTestFactory::buf_from_slice(&body),
+                true,
+            )
+            .unwrap();
+
+            let ev_headers = Event::Headers {
+                list: resp,
+                has_body: true,
+            };
+
+            assert_eq!(s.poll_client(), Ok((stream, ev_headers)));
+            // The first data cell
+            assert_eq!(s.poll_client(), Ok((stream, Event::Data)));
+            // We consume the first bytes.
+            let (b, tot_exp_len) = s.body_peek_client(stream).unwrap();
+            assert_eq!(b.len(), 79);
+            assert_eq!(tot_exp_len, 79);
+            assert!(s.body_consumed_client(stream, 79).is_ok());
+            // Now we should be able to poll the next data frame
+            assert_eq!(s.poll_client(), Ok((stream, Event::Data)));
+            let (b, _) = s.body_peek_client(stream).unwrap();
+            let len = b.len();
+            assert_eq!(len, body.len());
+            assert!(s.body_consumed_client(stream, len).is_ok());
+            assert_eq!(s.poll_client(), Ok((stream, Event::Finished)));
         }
     }
 
@@ -4207,7 +4339,6 @@ mod tests {
             }
         }
 
-        env_logger::builder().format_timestamp_nanos().init();
         assert_eq!(s.poll_server(), Ok((stream, Event::Finished)));
 
         let resp = s.send_response(stream, true).unwrap();

--- a/quiceh/src/h3/stream.rs
+++ b/quiceh/src/h3/stream.rs
@@ -187,11 +187,7 @@ impl Stream {
             state,
 
             // Pre-allocate a buffer to avoid multiple tiny early allocations.
-            state_buf: if qversion == crate::PROTOCOL_VERSION_VREVERSO {
-                vec![]
-            } else {
-                vec![0; 16]
-            },
+            state_buf: vec![0; 16],
 
             // Expect one byte for the initial state, to parse the initial
             // varint length.
@@ -453,9 +449,11 @@ impl Stream {
     pub fn mark_state_buffer_consumed<F: BufFactory>(
         &mut self, conn: &mut crate::Connection<F>, consumed: usize,
     ) -> Result<()> {
-        self.state_off += consumed;
+        if !self.state_buffer_complete() {
+            trace!("mark_state_buffer_consumed: Consuming {} bytes", consumed);
 
-        conn.stream_consumed(self.id, consumed)?;
+            conn.stream_consumed(self.id, consumed)?;
+        }
 
         self.reset_data_event();
 
@@ -579,9 +577,9 @@ impl Stream {
     fn mark_state_buffer_consumed_for_tests(
         &mut self, consumed: usize, stream: &mut std::io::Cursor<Vec<u8>>,
     ) -> Result<()> {
-        self.state_off += consumed;
-
-        stream.set_position(stream.position() + consumed as u64);
+        if !self.state_buffer_complete() {
+            stream.set_position(stream.position() + consumed as u64);
+        }
 
         self.reset_data_event();
 
@@ -605,19 +603,62 @@ impl Stream {
     }
 
     /// Update the state length an tries to consume the varint.
-    pub fn try_consume_varint_from_buf(&mut self, buf: &[u8]) -> Result<u64> {
+    pub fn try_consume_varint_from_buf(
+        &mut self, buf: &[u8],
+    ) -> Result<(Option<u64>, usize)> {
         // always parse the length
-        self.state_len = octets_rev::varint_parse_len(buf[0]);
-
-        // In case we don't have enough data pulled from QUIC.
-        if buf.len() < self.state_len {
-            self.reset_data_event();
-            return Err(Error::Done);
+        if self.state_off == 0 {
+            self.state_len = octets_rev::varint_parse_len(buf[0]);
         }
 
-        let varint = octets_rev::Octets::with_slice(buf).get_varint()?;
+        // In case we don't have enough data pulled from QUIC. This would
+        // happen if the frame header is across two StreamChunk. It is a rare
+        // event.
+        if buf.len() + self.state_off < self.state_len {
+            trace!(
+                "Read end of chunk state_off: {}, state_len: {}",
+                self.state_off,
+                self.state_len
+            );
 
-        Ok(varint)
+            let min = std::cmp::min(
+                self.state_len.saturating_sub(self.state_off),
+                buf.len(),
+            );
+            let state_buf_slice =
+                &mut self.state_buf[self.state_off..self.state_off + min];
+            state_buf_slice.copy_from_slice(&buf[..min]);
+            self.state_off += min;
+            self.reset_data_event();
+            Ok((None, min))
+        } else if buf.len() + self.state_off >= self.state_len
+            && self.state_off > 0
+            && self.state_off < self.state_len
+        {
+            trace!(
+                "Read across chunk state_off: {}, state_len: {}",
+                self.state_off,
+                self.state_len
+            );
+
+            // We can complete the state buf and consume the varint
+            let consumed = self.state_len.saturating_sub(self.state_off);
+            let state_buf_slice =
+                &mut self.state_buf[self.state_off..self.state_len];
+            state_buf_slice.copy_from_slice(&buf[..consumed]);
+
+            // state_off will be put back to 0 during state_transition.
+            self.state_off += consumed;
+
+            let varint =
+                octets_rev::Octets::with_slice(&self.state_buf).get_varint()?;
+
+            Ok((Some(varint), consumed))
+        } else {
+            let varint = octets_rev::Octets::with_slice(buf).get_varint()?;
+
+            Ok((Some(varint), 0))
+        }
     }
 
     /// Tries to parse a varint (including length) from the state buffer.
@@ -907,12 +948,12 @@ mod tests {
             if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
                 let b = stream.try_acquire_state_buffer_for_tests(cursor)?;
 
-                let varint = stream.try_consume_varint_from_buf(b)?;
+                let (varint, _) = stream.try_consume_varint_from_buf(b)?;
                 stream.mark_state_buffer_consumed_for_tests(
                     stream.get_state_len(),
                     cursor,
                 )?;
-                varint
+                varint.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(cursor)?;
 
@@ -933,12 +974,12 @@ mod tests {
             if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
                 let b = stream.try_acquire_state_buffer_for_tests(cursor)?;
 
-                let frame_ty = stream.try_consume_varint_from_buf(b)?;
+                let (frame_ty, _) = stream.try_consume_varint_from_buf(b)?;
                 stream.mark_state_buffer_consumed_for_tests(
                     stream.get_state_len(),
                     cursor,
                 )?;
-                frame_ty
+                frame_ty.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(cursor)?;
 
@@ -949,21 +990,22 @@ mod tests {
         assert_eq!(stream.state, State::FramePayloadLen);
 
         // Parse the frame payload length.
-        let frame_payload_len =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream.try_acquire_state_buffer_for_tests(cursor)?;
+        let frame_payload_len = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream.try_acquire_state_buffer_for_tests(cursor)?;
 
-                let frame_payload_len = stream.try_consume_varint_from_buf(b)?;
-                stream.mark_state_buffer_consumed_for_tests(
-                    stream.get_state_len(),
-                    cursor,
-                )?;
-                frame_payload_len
-            } else {
-                stream.try_fill_buffer_for_tests(cursor)?;
+            let (frame_payload_len, _) = stream.try_consume_varint_from_buf(b)?;
+            stream.mark_state_buffer_consumed_for_tests(
+                stream.get_state_len(),
+                cursor,
+            )?;
+            frame_payload_len.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(cursor)?;
 
-                stream.try_consume_varint()?
-            };
+            stream.try_consume_varint()?
+        };
 
         stream.set_frame_payload_len(frame_payload_len)?;
         assert_eq!(stream.state, State::FramePayload);
@@ -1020,25 +1062,26 @@ mod tests {
         assert_eq!(stream.state, State::FrameType);
 
         // Parse the SETTINGS frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::SETTINGS_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -1051,7 +1094,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -1059,7 +1102,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -1114,25 +1157,26 @@ mod tests {
         assert_eq!(stream.state, State::FrameType);
 
         // Parse the SETTINGS frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::SETTINGS_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -1145,7 +1189,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -1153,7 +1197,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -1216,25 +1260,26 @@ mod tests {
         assert_eq!(stream.state, State::FrameType);
 
         // Parse the SETTINGS frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::SETTINGS_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -1247,7 +1292,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -1255,7 +1300,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -1283,25 +1328,26 @@ mod tests {
         assert_eq!(stream.state, State::FrameType);
 
         // Parse the second SETTINGS frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(stream.set_frame_type(frame_ty), Err(Error::FrameUnexpected));
     }
 
@@ -1341,25 +1387,26 @@ mod tests {
         assert_eq!(stream.state, State::FrameType);
 
         // Parse GOAWAY.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(stream.set_frame_type(frame_ty), Err(Error::MissingSettings));
     }
 
@@ -1401,25 +1448,26 @@ mod tests {
         assert_eq!(stream.state, State::FrameType);
 
         // Parse first SETTINGS frame.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         stream.set_frame_type(frame_ty).unwrap();
 
         let frame_payload_len =
@@ -1428,7 +1476,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -1436,7 +1484,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -1444,14 +1492,18 @@ mod tests {
             };
         stream.set_frame_payload_len(frame_payload_len).unwrap();
 
+        env_logger::builder().format_timestamp_nanos().init();
         if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
             let b = stream
                 .try_acquire_state_buffer_for_tests(&mut cursor)
                 .unwrap();
 
-            stream.try_consume_frame_from_buf(b).unwrap();
+            let (_, payload_len) = stream.try_consume_frame_from_buf(b).unwrap();
             assert!(stream
-                .mark_state_buffer_consumed_for_tests(6, &mut cursor)
+                .mark_state_buffer_consumed_for_tests(
+                    payload_len as usize,
+                    &mut cursor
+                )
                 .is_ok());
         } else {
             stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
@@ -1459,25 +1511,26 @@ mod tests {
             stream.try_consume_frame().unwrap();
         }
         // Parse HEADERS.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(stream.set_frame_type(frame_ty), Err(Error::FrameUnexpected));
     }
 
@@ -1511,25 +1564,26 @@ mod tests {
         let mut cursor = std::io::Cursor::new(d);
 
         // Parse the HEADERS frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::HEADERS_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -1542,7 +1596,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -1550,7 +1604,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -1579,25 +1633,26 @@ mod tests {
         assert_eq!(stream.state, State::FrameType);
 
         // Parse the DATA frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::DATA_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -1610,7 +1665,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -1618,7 +1673,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -1682,14 +1737,14 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let push_id = stream.try_consume_varint_from_buf(b).unwrap();
+                let (push_id, _) = stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
                         stream.get_state_len(),
                         &mut cursor
                     )
                     .is_ok());
-                push_id
+                push_id.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -1701,25 +1756,26 @@ mod tests {
         assert_eq!(stream.state, State::FrameType);
 
         // Parse the HEADERS frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::HEADERS_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -1732,7 +1788,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -1740,7 +1796,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -1769,25 +1825,26 @@ mod tests {
         assert_eq!(stream.state, State::FrameType);
 
         // Parse the DATA frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::DATA_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -1800,7 +1857,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -1808,7 +1865,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -1852,25 +1909,26 @@ mod tests {
         let mut cursor = std::io::Cursor::new(d);
 
         // Parse stream type.
-        let stream_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let stream_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let stream_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                stream_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (stream_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            stream_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(stream_ty, 33);
         stream
             .set_ty(Type::deserialize(stream_ty).unwrap())
@@ -1894,25 +1952,26 @@ mod tests {
         let mut cursor = std::io::Cursor::new(d);
 
         // Parse the DATA frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::DATA_FRAME_TYPE_ID);
 
         assert_eq!(stream.set_frame_type(frame_ty), Err(Error::FrameUnexpected));
@@ -1950,25 +2009,26 @@ mod tests {
         parse_skip_frame(&mut stream, &mut cursor).unwrap();
 
         // Parse frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::GOAWAY_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -1981,7 +2041,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -1989,7 +2049,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -2018,25 +2078,26 @@ mod tests {
         let mut cursor = std::io::Cursor::new(d);
 
         // Parse frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::PUSH_PROMISE_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -2049,7 +2110,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -2057,7 +2118,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -2101,25 +2162,26 @@ mod tests {
         parse_skip_frame(&mut stream, &mut cursor).unwrap();
 
         // Parse frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::CANCEL_PUSH_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -2132,7 +2194,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -2140,7 +2202,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
@@ -2184,25 +2246,26 @@ mod tests {
         parse_skip_frame(&mut stream, &mut cursor).unwrap();
 
         // Parse frame type.
-        let frame_ty =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                let b = stream
-                    .try_acquire_state_buffer_for_tests(&mut cursor)
-                    .unwrap();
+        let frame_ty = if crate::PROTOCOL_VERSION
+            == crate::PROTOCOL_VERSION_VREVERSO
+        {
+            let b = stream
+                .try_acquire_state_buffer_for_tests(&mut cursor)
+                .unwrap();
 
-                let frame_ty = stream.try_consume_varint_from_buf(b).unwrap();
-                assert!(stream
-                    .mark_state_buffer_consumed_for_tests(
-                        stream.get_state_len(),
-                        &mut cursor
-                    )
-                    .is_ok());
-                frame_ty
-            } else {
-                stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
+            let (frame_ty, _) = stream.try_consume_varint_from_buf(b).unwrap();
+            assert!(stream
+                .mark_state_buffer_consumed_for_tests(
+                    stream.get_state_len(),
+                    &mut cursor
+                )
+                .is_ok());
+            frame_ty.unwrap()
+        } else {
+            stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 
-                stream.try_consume_varint().unwrap()
-            };
+            stream.try_consume_varint().unwrap()
+        };
         assert_eq!(frame_ty, frame::MAX_PUSH_FRAME_TYPE_ID);
 
         stream.set_frame_type(frame_ty).unwrap();
@@ -2215,7 +2278,7 @@ mod tests {
                     .try_acquire_state_buffer_for_tests(&mut cursor)
                     .unwrap();
 
-                let frame_payload_len =
+                let (frame_payload_len, _) =
                     stream.try_consume_varint_from_buf(b).unwrap();
                 assert!(stream
                     .mark_state_buffer_consumed_for_tests(
@@ -2223,7 +2286,7 @@ mod tests {
                         &mut cursor
                     )
                     .is_ok());
-                frame_payload_len
+                frame_payload_len.unwrap()
             } else {
                 stream.try_fill_buffer_for_tests(&mut cursor).unwrap();
 


### PR DESCRIPTION
This was causing HTTP/3 connections to stall if by chance, a DATA frame header was written across two buffers from the bufferpool