### PR TITLE
build: replace manual FFI with generated sys bindings

### DIFF
--- a/quiceh/.cargo/config.toml
+++ b/quiceh/.cargo/config.toml
@@ -1,2 +1,0 @@
-[env]
-AWS_LC_SYS_NO_PREFIX = "1"

--- a/quiceh/src/crypto/boringssl_or_aws.rs
+++ b/quiceh/src/crypto/boringssl_or_aws.rs
@@ -377,55 +377,78 @@ pub(crate) fn hkdf_expand(
 
     Ok(())
 }
-extern "C" {
-    fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
+#[cfg(feature = "aws-lc")]
+use aws_lc_sys as sys;
+#[cfg(feature = "boringssl-boring-crate")]
+use boring_sys as sys;
 
-    fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
-
-    fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
-
-    // HKDF
-    fn HKDF_extract(
-        out_key: *mut u8, out_len: *mut usize, digest: *const EVP_MD,
-        secret: *const u8, secret_len: usize, salt: *const u8, salt_len: usize,
-    ) -> c_int;
-
-    fn HKDF_expand(
-        out_key: *mut u8, out_len: usize, digest: *const EVP_MD, prk: *const u8,
-        prk_len: usize, info: *const u8, info_len: usize,
-    ) -> c_int;
-
-    // EVP_AEAD_CTX
-    fn EVP_AEAD_CTX_init(
-        ctx: *mut EVP_AEAD_CTX, aead: *const EVP_AEAD, key: *const u8,
-        key_len: usize, tag_len: usize, engine: *mut c_void,
-    ) -> c_int;
-
-    fn EVP_AEAD_CTX_open(
-        ctx: *const EVP_AEAD_CTX, out: *mut u8, out_len: *mut usize,
-        max_out_len: usize, nonce: *const u8, nonce_len: usize, inp: *const u8,
-        in_len: usize, ad: *const u8, ad_len: usize,
-    ) -> c_int;
-
-    fn EVP_AEAD_CTX_seal_scatter(
-        ctx: *const EVP_AEAD_CTX, out: *mut u8, out_tag: *mut u8,
-        out_tag_len: *mut usize, max_out_tag_len: usize, nonce: *const u8,
-        nonce_len: usize, inp: *const u8, in_len: usize, extra_in: *const u8,
-        extra_in_len: usize, ad: *const u8, ad_len: usize,
-    ) -> c_int;
-
-    // AES
-    fn AES_set_encrypt_key(
-        key: *const u8, bits: c_uint, aeskey: *mut AES_KEY,
-    ) -> c_int;
-
-    fn AES_ecb_encrypt(
-        inp: *const u8, out: *mut u8, key: *const AES_KEY, enc: c_int,
-    ) -> c_void;
-
-    // ChaCha20
-    fn CRYPTO_chacha_20(
-        out: *mut u8, inp: *const u8, in_len: usize, key: *const u8,
-        nonce: *const u8, counter: u32,
-    ) -> c_void;
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD {
+    sys::EVP_aead_aes_128_gcm_tls13() as _
 }
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD {
+    sys::EVP_aead_aes_256_gcm_tls13() as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD {
+    sys::EVP_aead_chacha20_poly1305() as _
+}
+
+// HKDF
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn HKDF_extract( out_key: *mut u8, out_len: *mut usize, digest: *const EVP_MD, secret: *const u8, secret_len: usize, salt: *const u8, salt_len: usize, ) -> c_int {
+    sys::HKDF_extract(out_key as _, out_len as _, digest as _, secret as _, secret_len as _, salt as _, salt_len as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn HKDF_expand( out_key: *mut u8, out_len: usize, digest: *const EVP_MD, prk: *const u8, prk_len: usize, info: *const u8, info_len: usize, ) -> c_int {
+    sys::HKDF_expand(out_key as _, out_len as _, digest as _, prk as _, prk_len as _, info as _, info_len as _) as _
+}
+
+// EVP_AEAD_CTX
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn EVP_AEAD_CTX_init( ctx: *mut EVP_AEAD_CTX, aead: *const EVP_AEAD, key: *const u8, key_len: usize, tag_len: usize, engine: *mut c_void, ) -> c_int {
+    sys::EVP_AEAD_CTX_init(ctx as _, aead as _, key as _, key_len as _, tag_len as _, engine as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn EVP_AEAD_CTX_open( ctx: *const EVP_AEAD_CTX, out: *mut u8, out_len: *mut usize, max_out_len: usize, nonce: *const u8, nonce_len: usize, inp: *const u8, in_len: usize, ad: *const u8, ad_len: usize, ) -> c_int {
+    sys::EVP_AEAD_CTX_open(ctx as _, out as _, out_len as _, max_out_len as _, nonce as _, nonce_len as _, inp as _, in_len as _, ad as _, ad_len as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn EVP_AEAD_CTX_seal_scatter( ctx: *const EVP_AEAD_CTX, out: *mut u8, out_tag: *mut u8, out_tag_len: *mut usize, max_out_tag_len: usize, nonce: *const u8, nonce_len: usize, inp: *const u8, in_len: usize, extra_in: *const u8, extra_in_len: usize, ad: *const u8, ad_len: usize, ) -> c_int {
+    sys::EVP_AEAD_CTX_seal_scatter(ctx as _, out as _, out_tag as _, out_tag_len as _, max_out_tag_len as _, nonce as _, nonce_len as _, inp as _, in_len as _, extra_in as _, extra_in_len as _, ad as _, ad_len as _) as _
+}
+
+// AES
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn AES_set_encrypt_key( key: *const u8, bits: c_uint, aeskey: *mut AES_KEY, ) -> c_int {
+    sys::AES_set_encrypt_key(key as _, bits as _, aeskey as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn AES_ecb_encrypt( inp: *const u8, out: *mut u8, key: *const AES_KEY, enc: c_int, ) {
+    sys::AES_ecb_encrypt(inp as _, out as _, key as _, enc as _);
+}
+
+// ChaCha20
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn CRYPTO_chacha_20( out: *mut u8, inp: *const u8, in_len: usize, key: *const u8, nonce: *const u8, counter: u32, ) {
+    sys::CRYPTO_chacha_20(out as _, inp as _, in_len as _, key as _, nonce as _, counter as _);
+}
+

--- a/quiceh/src/crypto/mod.rs
+++ b/quiceh/src/crypto/mod.rs
@@ -541,14 +541,30 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<()> {
     Err(Error::CryptoFail)
 }
 
-extern "C" {
-    fn EVP_sha256() -> *const EVP_MD;
+#[cfg(feature = "aws-lc")]
+use aws_lc_sys as sys;
+#[cfg(feature = "boringssl-boring-crate")]
+use boring_sys as sys;
 
-    fn EVP_sha384() -> *const EVP_MD;
-
-    // CRYPTO
-    fn CRYPTO_memcmp(a: *const u8, b: *const u8, len: usize) -> c_int;
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn EVP_sha256() -> *const EVP_MD {
+    sys::EVP_sha256() as _
 }
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn EVP_sha384() -> *const EVP_MD {
+    sys::EVP_sha384() as _
+}
+
+// CRYPTO
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn CRYPTO_memcmp(a: *const u8, b: *const u8, len: usize) -> c_int {
+    sys::CRYPTO_memcmp(a as _, b as _, len as _) as _
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/quiceh/src/rand.rs
+++ b/quiceh/src/rand.rs
@@ -59,6 +59,14 @@ pub fn rand_u64_uniform(max: u64) -> u64 {
     r / chunk_size
 }
 
-extern "C" {
-    fn RAND_bytes(buf: *mut u8, len: libc::size_t) -> libc::c_int;
+#[cfg(feature = "aws-lc")]
+use aws_lc_sys as sys;
+#[cfg(feature = "boringssl-boring-crate")]
+use boring_sys as sys;
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn RAND_bytes(buf: *mut u8, len: libc::size_t) -> libc::c_int {
+    sys::RAND_bytes(buf as _, len as _) as _
 }
+

--- a/quiceh/src/tls/boringssl_or_aws.rs
+++ b/quiceh/src/tls/boringssl_or_aws.rs
@@ -293,81 +293,160 @@ pub(super) fn get_session_bytes(session: *mut SSL_SESSION) -> Result<Vec<u8>> {
 }
 pub(super) const TLS_ERROR: c_int = 3;
 
-extern "C" {
-    // SSL_METHOD specific for boringssl.
-    pub(super) fn SSL_CTX_set_tlsext_ticket_keys(
-        ctx: *mut SSL_CTX, key: *const u8, key_len: usize,
-    ) -> c_int;
-    fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: i32);
+#[cfg(feature = "aws-lc")]
+use aws_lc_sys as sys;
+#[cfg(feature = "boringssl-boring-crate")]
+use boring_sys as sys;
 
-    pub(super) fn SSL_CTX_set_session_cache_mode(
-        ctx: *mut SSL_CTX, mode: c_int,
-    ) -> c_int;
-    pub(super) fn SSL_get_ex_new_index(
-        argl: c_long, argp: *const c_void, unused: *const c_void,
-        dup_unused: *const c_void, free_func: *const c_void,
-    ) -> c_int;
-
-    fn SSL_get_curve_id(ssl: *const SSL) -> u16;
-    fn SSL_get_curve_name(curve: u16) -> *const c_char;
-
-    fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16;
-    fn SSL_get_signature_algorithm_name(
-        sigalg: u16, include_curve: i32,
-    ) -> *const c_char;
-
-    fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const STACK_OF;
-
-    pub(super) fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16)
-        -> c_int;
-
-    pub(super) fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16)
-        -> c_int;
-
-    pub(super) fn SSL_set_tlsext_host_name(
-        ssl: *mut SSL, name: *const c_char,
-    ) -> c_int;
-
-    fn SSL_set_quic_early_data_context(
-        ssl: *mut SSL, context: *const u8, context_len: usize,
-    ) -> c_int;
-
-    #[cfg(test)]
-    fn SSL_set_private_key_method(
-        ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD,
-    );
-
-    fn SSL_reset_early_data_reject(ssl: *mut SSL);
-
-    fn SSL_in_early_data(ssl: *const SSL) -> c_int;
-
-    fn SSL_SESSION_to_bytes(
-        session: *const SSL_SESSION, out: *mut *mut u8, out_len: *mut usize,
-    ) -> c_int;
-
-    fn SSL_SESSION_from_bytes(
-        input: *const u8, input_len: usize, ctx: *const SSL_CTX,
-    ) -> *mut SSL_SESSION;
-
-    // STACK_OF
-
-    #[cfg(feature = "boringssl-boring-crate")]
-    fn sk_num(stack: *const STACK_OF) -> usize;
-
-    #[cfg(feature = "boringssl-boring-crate")]
-    fn sk_value(stack: *const STACK_OF, idx: usize) -> *mut c_void;
-
-    #[cfg(all(feature = "aws-lc", not(feature = "boringssl-boring-crate")))]
-    #[link_name = "OPENSSL_sk_num"]
-    fn sk_num(stack: *const STACK_OF) -> usize;
-
-    #[cfg(all(feature = "aws-lc", not(feature = "boringssl-boring-crate")))]
-    #[link_name = "OPENSSL_sk_value"]
-    fn sk_value(stack: *const STACK_OF, idx: usize) -> *mut c_void;
-
-    // CRYPTO_BUFFER
-
-    fn CRYPTO_BUFFER_len(buffer: *const CRYPTO_BUFFER) -> usize;
-
-    fn CRYPTO_BUFFER_data(buffer: *const CRYPTO_BUFFER) -> *const u8;
+// SSL_METHOD specific for boringssl.
+#[inline]
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_CTX_set_tlsext_ticket_keys( ctx: *mut SSL_CTX, key: *const u8, key_len: usize, ) -> c_int {
+    sys::SSL_CTX_set_tlsext_ticket_keys(ctx as _, key as _, key_len as _) as _
 }
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: i32) {
+    sys::SSL_CTX_set_early_data_enabled(ctx as _, enabled as _);
+}
+
+#[inline]
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_CTX_set_session_cache_mode( ctx: *mut SSL_CTX, mode: c_int, ) -> c_int {
+    sys::SSL_CTX_set_session_cache_mode(ctx as _, mode as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_get_ex_new_index( argl: c_long, argp: *const c_void, unused: *const c_void, dup_unused: *const c_void, free_func: *const c_void, ) -> c_int {
+    sys::SSL_get_ex_new_index(argl as _, argp as _, std::mem::transmute(unused), std::mem::transmute(dup_unused), std::mem::transmute(free_func)) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get_curve_id(ssl: *const SSL) -> u16 {
+    sys::SSL_get_curve_id(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get_curve_name(curve: u16) -> *const c_char {
+    sys::SSL_get_curve_name(curve as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get_peer_signature_algorithm(ssl: *const SSL) -> u16 {
+    sys::SSL_get_peer_signature_algorithm(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get_signature_algorithm_name( sigalg: u16, include_curve: i32, ) -> *const c_char {
+    sys::SSL_get_signature_algorithm_name(sigalg as _, include_curve as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get0_peer_certificates(ssl: *const SSL) -> *const STACK_OF {
+    sys::SSL_get0_peer_certificates(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_set_min_proto_version(ssl: *mut SSL, version: u16) -> c_int {
+    sys::SSL_set_min_proto_version(ssl as _, version as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_set_max_proto_version(ssl: *mut SSL, version: u16) -> c_int {
+    sys::SSL_set_max_proto_version(ssl as _, version as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+pub(super) unsafe fn SSL_set_tlsext_host_name( ssl: *mut SSL, name: *const c_char, ) -> c_int {
+    sys::SSL_set_tlsext_host_name(ssl as _, name as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_quic_early_data_context( ssl: *mut SSL, context: *const u8, context_len: usize, ) -> c_int {
+    sys::SSL_set_quic_early_data_context(ssl as _, context as _, context_len as _) as _
+}
+
+#[cfg(test)]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_private_key_method( ssl: *mut SSL, key_method: *const SSL_PRIVATE_KEY_METHOD, ) {
+    sys::SSL_set_private_key_method(ssl as _, key_method as _);
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_reset_early_data_reject(ssl: *mut SSL) {
+    sys::SSL_reset_early_data_reject(ssl as _);
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_in_early_data(ssl: *const SSL) -> c_int {
+    sys::SSL_in_early_data(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_SESSION_to_bytes( session: *const SSL_SESSION, out: *mut *mut u8, out_len: *mut usize, ) -> c_int {
+    sys::SSL_SESSION_to_bytes(session as _, out as _, out_len as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_SESSION_from_bytes( input: *const u8, input_len: usize, ctx: *const SSL_CTX, ) -> *mut SSL_SESSION {
+    sys::SSL_SESSION_from_bytes(input as _, input_len as _, ctx as _) as _
+}
+
+// STACK_OF
+#[cfg(feature = "boringssl-boring-crate")]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn sk_num(stack: *const STACK_OF) -> usize {
+    sys::sk_num(stack as _) as _
+}
+
+#[cfg(feature = "boringssl-boring-crate")]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn sk_value(stack: *const STACK_OF, idx: usize) -> *mut c_void {
+    sys::sk_value(stack as _, idx as _) as _
+}
+
+#[cfg(all(feature = "aws-lc", not(feature = "boringssl-boring-crate")))]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn sk_num(stack: *const STACK_OF) -> usize {
+    sys::OPENSSL_sk_num(stack as _) as _
+}
+
+#[cfg(all(feature = "aws-lc", not(feature = "boringssl-boring-crate")))]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn sk_value(stack: *const STACK_OF, idx: usize) -> *mut c_void {
+    sys::OPENSSL_sk_value(stack as _, idx as _) as _
+}
+
+// CRYPTO_BUFFER
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn CRYPTO_BUFFER_len(buffer: *const CRYPTO_BUFFER) -> usize {
+    sys::CRYPTO_BUFFER_len(buffer as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn CRYPTO_BUFFER_data(buffer: *const CRYPTO_BUFFER) -> *const u8 {
+    sys::CRYPTO_BUFFER_data(buffer as _) as _
+}
+

--- a/quiceh/src/tls/mod.rs
+++ b/quiceh/src/tls/mod.rs
@@ -1057,172 +1057,317 @@ fn log_ssl_error() {
     trace!("{}", std::str::from_utf8(&err).unwrap());
 }
 
-extern "C" {
-    // Note: some vendor-specific methods are implemented by each vendor's
-    // submodule (openssl-quictls / boringssl).
+#[cfg(feature = "aws-lc")]
+use aws_lc_sys as sys;
+#[cfg(feature = "boringssl-boring-crate")]
+use boring_sys as sys;
 
-    // SSL_METHOD
-    fn TLS_method() -> *const SSL_METHOD;
-
-    // SSL_CTX
-    fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
-    fn SSL_CTX_free(ctx: *mut SSL_CTX);
-
-    fn SSL_CTX_use_certificate_chain_file(
-        ctx: *mut SSL_CTX, file: *const c_char,
-    ) -> c_int;
-
-    fn SSL_CTX_use_PrivateKey_file(
-        ctx: *mut SSL_CTX, file: *const c_char, ty: c_int,
-    ) -> c_int;
-
-    fn SSL_CTX_load_verify_locations(
-        ctx: *mut SSL_CTX, file: *const c_char, path: *const c_char,
-    ) -> c_int;
-
-    #[cfg(not(windows))]
-    fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> c_int;
-
-    #[cfg(windows)]
-    fn SSL_CTX_get_cert_store(ctx: *mut SSL_CTX) -> *mut X509_STORE;
-
-    fn SSL_CTX_set_verify(
-        ctx: *mut SSL_CTX, mode: c_int,
-        cb: Option<
-            unsafe extern "C" fn(
-                ok: c_int,
-                store_ctx: *mut X509_STORE_CTX,
-            ) -> c_int,
-        >,
-    );
-
-    fn SSL_CTX_set_keylog_callback(
-        ctx: *mut SSL_CTX,
-        cb: Option<unsafe extern "C" fn(ssl: *const SSL, line: *const c_char)>,
-    );
-
-    fn SSL_CTX_set_alpn_protos(
-        ctx: *mut SSL_CTX, protos: *const u8, protos_len: usize,
-    ) -> c_int;
-
-    fn SSL_CTX_set_alpn_select_cb(
-        ctx: *mut SSL_CTX,
-        cb: Option<
-            unsafe extern "C" fn(
-                ssl: *mut SSL,
-                out: *mut *const u8,
-                out_len: *mut u8,
-                inp: *mut u8,
-                in_len: c_uint,
-                arg: *mut c_void,
-            ) -> c_int,
-        >,
-        arg: *mut c_void,
-    );
-
-    fn SSL_CTX_sess_set_new_cb(
-        ctx: *mut SSL_CTX,
-        cb: Option<
-            unsafe extern "C" fn(
-                ssl: *mut SSL,
-                session: *mut SSL_SESSION,
-            ) -> c_int,
-        >,
-    );
-
-    fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
-
-    fn SSL_get_error(ssl: *const SSL, ret_code: c_int) -> c_int;
-
-    fn SSL_set_accept_state(ssl: *mut SSL);
-    fn SSL_set_connect_state(ssl: *mut SSL);
-
-    fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM;
-
-    fn SSL_set_ex_data(ssl: *mut SSL, idx: c_int, ptr: *mut c_void) -> c_int;
-    fn SSL_get_ex_data(ssl: *const SSL, idx: c_int) -> *mut c_void;
-
-    fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER;
-
-    fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int;
-
-    fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
-
-    fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: c_int);
-
-    fn SSL_set_quic_transport_params(
-        ssl: *mut SSL, params: *const u8, params_len: usize,
-    ) -> c_int;
-
-    fn SSL_set_quic_method(
-        ssl: *mut SSL, quic_method: *const SSL_QUIC_METHOD,
-    ) -> c_int;
-
-    fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: c_int);
-
-    #[cfg(test)]
-    fn SSL_set_options(ssl: *mut SSL, opts: u32) -> u32;
-
-    fn SSL_get_peer_quic_transport_params(
-        ssl: *const SSL, out_params: *mut *const u8, out_params_len: *mut usize,
-    );
-
-    fn SSL_get0_alpn_selected(
-        ssl: *const SSL, out: *mut *const u8, out_len: *mut u32,
-    );
-
-    fn SSL_get_servername(ssl: *const SSL, ty: c_int) -> *const c_char;
-
-    fn SSL_provide_quic_data(
-        ssl: *mut SSL, level: crypto::Level, data: *const u8, len: usize,
-    ) -> c_int;
-
-    fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> c_int;
-
-    fn SSL_do_handshake(ssl: *mut SSL) -> c_int;
-
-    fn SSL_quic_write_level(ssl: *const SSL) -> crypto::Level;
-
-    fn SSL_session_reused(ssl: *const SSL) -> c_int;
-
-    fn SSL_in_init(ssl: *const SSL) -> c_int;
-
-    fn SSL_clear(ssl: *mut SSL) -> c_int;
-
-    fn SSL_free(ssl: *mut SSL);
-
-    // SSL_CIPHER
-    fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> c_uint;
-
-    // SSL_SESSION
-
-    fn SSL_SESSION_free(session: *mut SSL_SESSION);
-
-    // X509_VERIFY_PARAM
-    fn X509_VERIFY_PARAM_set1_host(
-        param: *mut X509_VERIFY_PARAM, name: *const c_char, namelen: usize,
-    ) -> c_int;
-
-    // X509_STORE
-    #[cfg(windows)]
-    fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> c_int;
-
-    // X509
-    #[cfg(windows)]
-    fn X509_free(x: *mut X509);
-    #[cfg(windows)]
-    fn d2i_X509(px: *mut X509, input: *const *const u8, len: c_int) -> *mut X509;
-
-    // ERR
-    fn ERR_peek_error() -> c_uint;
-
-    fn ERR_error_string_n(err: c_uint, buf: *mut c_char, len: usize);
-
-    // OPENSSL
-    #[allow(dead_code)]
-    fn OPENSSL_free(ptr: *mut c_void);
-
+// Note: some vendor-specific methods are implemented by each vendor's
+// submodule (openssl-quictls / boringssl).
+// SSL_METHOD
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn TLS_method() -> *const SSL_METHOD {
+    sys::TLS_method() as _
 }
+
+// SSL_CTX
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX {
+    sys::SSL_CTX_new(method as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_free(ctx: *mut SSL_CTX) {
+    sys::SSL_CTX_free(ctx as _);
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_use_certificate_chain_file( ctx: *mut SSL_CTX, file: *const c_char, ) -> c_int {
+    sys::SSL_CTX_use_certificate_chain_file(ctx as _, file as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_use_PrivateKey_file( ctx: *mut SSL_CTX, file: *const c_char, ty: c_int, ) -> c_int {
+    sys::SSL_CTX_use_PrivateKey_file(ctx as _, file as _, ty as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_load_verify_locations( ctx: *mut SSL_CTX, file: *const c_char, path: *const c_char, ) -> c_int {
+    sys::SSL_CTX_load_verify_locations(ctx as _, file as _, path as _) as _
+}
+
+#[cfg(not(windows))]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_set_default_verify_paths(ctx: *mut SSL_CTX) -> c_int {
+    sys::SSL_CTX_set_default_verify_paths(ctx as _) as _
+}
+
+#[cfg(windows)]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_get_cert_store(ctx: *mut SSL_CTX) -> *mut X509_STORE {
+    sys::SSL_CTX_get_cert_store(ctx as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_set_verify( ctx: *mut SSL_CTX, mode: c_int, cb: Option< unsafe extern "C" fn( ok: c_int, store_ctx: *mut X509_STORE_CTX, ) -> c_int, >, ) {
+    sys::SSL_CTX_set_verify(ctx as _, mode as _, std::mem::transmute(cb));
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_set_keylog_callback( ctx: *mut SSL_CTX, cb: Option<unsafe extern "C" fn(ssl: *const SSL, line: *const c_char)>, ) {
+    sys::SSL_CTX_set_keylog_callback(ctx as _, std::mem::transmute(cb));
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_set_alpn_protos( ctx: *mut SSL_CTX, protos: *const u8, protos_len: usize, ) -> c_int {
+    sys::SSL_CTX_set_alpn_protos(ctx as _, protos as _, protos_len as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_set_alpn_select_cb( ctx: *mut SSL_CTX, cb: Option< unsafe extern "C" fn( ssl: *mut SSL, out: *mut *const u8, out_len: *mut u8, inp: *mut u8, in_len: c_uint, arg: *mut c_void, ) -> c_int, >, arg: *mut c_void, ) {
+    sys::SSL_CTX_set_alpn_select_cb(ctx as _, std::mem::transmute(cb), arg as _);
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CTX_sess_set_new_cb( ctx: *mut SSL_CTX, cb: Option< unsafe extern "C" fn( ssl: *mut SSL, session: *mut SSL_SESSION, ) -> c_int, >, ) {
+    sys::SSL_CTX_sess_set_new_cb(ctx as _, std::mem::transmute(cb));
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL {
+    sys::SSL_new(ctx as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get_error(ssl: *const SSL, ret_code: c_int) -> c_int {
+    sys::SSL_get_error(ssl as _, ret_code as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_accept_state(ssl: *mut SSL) {
+    sys::SSL_set_accept_state(ssl as _);
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_connect_state(ssl: *mut SSL) {
+    sys::SSL_set_connect_state(ssl as _);
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get0_param(ssl: *mut SSL) -> *mut X509_VERIFY_PARAM {
+    sys::SSL_get0_param(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_ex_data(ssl: *mut SSL, idx: c_int, ptr: *mut c_void) -> c_int {
+    sys::SSL_set_ex_data(ssl as _, idx as _, ptr as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get_ex_data(ssl: *const SSL, idx: c_int) -> *mut c_void {
+    sys::SSL_get_ex_data(ssl as _, idx as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get_current_cipher(ssl: *const SSL) -> *const SSL_CIPHER {
+    sys::SSL_get_current_cipher(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_session(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int {
+    sys::SSL_set_session(ssl as _, session as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX {
+    sys::SSL_get_SSL_CTX(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: c_int) {
+    sys::SSL_set_quiet_shutdown(ssl as _, mode as _);
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_quic_transport_params( ssl: *mut SSL, params: *const u8, params_len: usize, ) -> c_int {
+    sys::SSL_set_quic_transport_params(ssl as _, params as _, params_len as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_quic_method( ssl: *mut SSL, quic_method: *const SSL_QUIC_METHOD, ) -> c_int {
+    sys::SSL_set_quic_method(ssl as _, quic_method as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_quic_use_legacy_codepoint(ssl: *mut SSL, use_legacy: c_int) {
+    sys::SSL_set_quic_use_legacy_codepoint(ssl as _, use_legacy as _);
+}
+
+#[cfg(test)]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_set_options(ssl: *mut SSL, opts: u32) -> u32 {
+    sys::SSL_set_options(ssl as _, opts as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get_peer_quic_transport_params( ssl: *const SSL, out_params: *mut *const u8, out_params_len: *mut usize, ) {
+    sys::SSL_get_peer_quic_transport_params(ssl as _, out_params as _, out_params_len as _);
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get0_alpn_selected( ssl: *const SSL, out: *mut *const u8, out_len: *mut u32, ) {
+    sys::SSL_get0_alpn_selected(ssl as _, out as _, out_len as _);
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_get_servername(ssl: *const SSL, ty: c_int) -> *const c_char {
+    sys::SSL_get_servername(ssl as _, ty as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_provide_quic_data( ssl: *mut SSL, level: crypto::Level, data: *const u8, len: usize, ) -> c_int {
+    sys::SSL_provide_quic_data(ssl as _, level as _, data as _, len as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_process_quic_post_handshake(ssl: *mut SSL) -> c_int {
+    sys::SSL_process_quic_post_handshake(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_do_handshake(ssl: *mut SSL) -> c_int {
+    sys::SSL_do_handshake(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_quic_write_level(ssl: *const SSL) -> crypto::Level {
+    std::mem::transmute(sys::SSL_quic_write_level(ssl as _))
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_session_reused(ssl: *const SSL) -> c_int {
+    sys::SSL_session_reused(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_in_init(ssl: *const SSL) -> c_int {
+    sys::SSL_in_init(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_clear(ssl: *mut SSL) -> c_int {
+    sys::SSL_clear(ssl as _) as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_free(ssl: *mut SSL) {
+    sys::SSL_free(ssl as _);
+}
+
+// SSL_CIPHER
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_CIPHER_get_id(cipher: *const SSL_CIPHER) -> c_uint {
+    sys::SSL_CIPHER_get_id(cipher as _) as _
+}
+
+// SSL_SESSION
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn SSL_SESSION_free(session: *mut SSL_SESSION) {
+    sys::SSL_SESSION_free(session as _);
+}
+
+// X509_VERIFY_PARAM
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn X509_VERIFY_PARAM_set1_host( param: *mut X509_VERIFY_PARAM, name: *const c_char, namelen: usize, ) -> c_int {
+    sys::X509_VERIFY_PARAM_set1_host(param as _, name as _, namelen as _) as _
+}
+
+// X509_STORE
+#[cfg(windows)]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn X509_STORE_add_cert(ctx: *mut X509_STORE, x: *mut X509) -> c_int {
+    sys::X509_STORE_add_cert(ctx as _, x as _) as _
+}
+
+// X509
+#[cfg(windows)]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn X509_free(x: *mut X509) {
+    sys::X509_free(x as _);
+}
+
+#[cfg(windows)]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn d2i_X509(px: *mut X509, input: *const *const u8, len: c_int) -> *mut X509 {
+    sys::d2i_X509(px as _, input as _, len as _) as _
+}
+
+// ERR
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn ERR_peek_error() -> c_uint {
+    sys::ERR_peek_error() as _
+}
+
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn ERR_error_string_n(err: c_uint, buf: *mut c_char, len: usize) {
+    sys::ERR_error_string_n(err as _, buf as _, len as _);
+}
+
+// OPENSSL
+#[allow(dead_code)]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn OPENSSL_free(ptr: *mut c_void) {
+    sys::OPENSSL_free(ptr as _);
+}
+
 
 mod boringssl_or_aws;
 use boringssl_or_aws::*;


### PR DESCRIPTION
Remove the manual `extern "C"` blocks and opaque type definitions for OpenSSL/BoringSSL/AWS-LC FFI functions. Instead, use the bindings provided by `aws-lc-sys` and `boring-sys` directly.

By using the `sys` bindings natively instead of hardcoding FFI declarations, we eliminate the need for dependent projects to configure `AWS_LC_SYS_NO_PREFIX = "1"`. The compiler will now correctly resolve the prefixed symbols generated by `aws-lc-sys`.