### PR TITLE
refactoring: adding traits OctetsRead and OctetsWrite implemented for…

### DIFF
--- a/octets_rev/Cargo.toml
+++ b/octets_rev/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["network-programming"]
 license = "BSD-2-Clause"
 
 [dependencies]
-likely_stable = "0.1.3"
+branches = "0.4.4"

--- a/octets_rev/README.md
+++ b/octets_rev/README.md
@@ -1,0 +1,107 @@
+# octets-rev
+
+A fork of [quiche's octets crate](https://github.com/cloudflare/quiche) with backward processing logic added.
+
+This crate provides a set of types for safely and efficiently reading from and writing to byte buffers, designed for performance-critical applications like network protocol implementations where minimizing copies is essential.
+
+## Key Difference: Backward Processing
+
+Unlike the original octets crate, this fork adds support for **backward (right-to-left) processing** in addition to the standard forward (left-to-right) processing. This is particularly useful for:
+
+- Protocols that define fields relative to the end of a packet
+- Building packets from both ends to avoid moving data
+- Parsing protocols where headers or metadata appear at the end
+
+The crate provides four types:
+- `Octets` / `OctetsMut`: Forward processing (beginning → end)
+- `OctetsRev` / `OctetsMutRev`: Backward processing (end → beginning)
+
+## Examples
+
+### Reading from a buffer
+
+```rust
+use octets_rev::Octets;
+
+let data = [0x01, 0x00, 0x42, 0x05, b'h', b'e', b'l', b'l', b'o'];
+let mut b = Octets::with_slice(&data);
+
+assert_eq!(b.get_u8(), Ok(1));
+assert_eq!(b.get_u16(), Ok(0x0042));
+
+let mut sub = b.get_bytes_with_u8_length().unwrap();
+assert_eq!(sub.as_ref(), b"hello");
+```
+
+### Forward and Backward Processing
+
+```rust
+use octets_rev::{OctetsMut, OctetsMutRev, Octets, OctetsRev};
+
+let mut data = [0; 10];
+
+// Write 0x01 at the beginning
+{
+    let mut b = OctetsMut::with_slice(&mut data);
+    b.put_u8(0x01).unwrap();
+}
+
+// Write 0xFE at the end
+{
+    let mut b = OctetsMutRev::with_slice(&mut data);
+    b.put_u8(0xFE).unwrap();
+}
+
+assert_eq!(data[0], 0x01);
+assert_eq!(data[9], 0xFE);
+
+// Read them back
+let mut forward = Octets::with_slice(&data);
+assert_eq!(forward.get_u8(), Ok(0x01));
+
+let mut backward = OctetsRev::with_slice(&data);
+assert_eq!(backward.get_u8(), Ok(0xFE));
+```
+
+### Generic Processing with Traits
+
+By using the [`OctetsRead`] and [`OctetsWrite`] traits, you can write generic code that works identically for both forward and backward buffers. This is possible because `OctetsRev` and `OctetsMutRev` ensure that "reading the next integer" always moves the cursor in the "natural" direction for that buffer.
+
+```rust
+use octets_rev::{OctetsRead, Octets, OctetsRev, Result};
+
+struct Frame {
+    ty: u8,
+    id: u16,
+}
+
+impl Frame {
+    /// This code is oblivious to whether R is forward or backward.
+    /// It just reads the "next" fields in the defined logical order.
+    fn parse<R: OctetsRead>(r: &mut R) -> Result<Self> {
+        let ty = r.get_u8()?;
+        let id = r.get_u16()?;
+        Ok(Frame { ty, id })
+    }
+}
+
+// Forward processing: Type=1, ID=0x0042.
+// Data is physically [0x01, 0x00, 0x42].
+{
+    let data = [0x01, 0x00, 0x42];
+    let mut forward = Octets::with_slice(&data);
+    let f_frame = Frame::parse(&mut forward).unwrap();
+    assert_eq!(f_frame.ty, 0x01);
+    assert_eq!(f_frame.id, 0x0042);
+}
+
+// Backward processing: Type=1, ID=0x0042.
+// Data is physically [0x00, 0x42, 0x01] because OctetsRev reads from the end.
+{
+    let data = [0x00, 0x42, 0x01];
+    let mut backward = OctetsRev::with_slice(&data);
+    let b_frame = Frame::parse(&mut backward).unwrap();
+    assert_eq!(b_frame.ty, 0x01);
+    assert_eq!(b_frame.id, 0x0042);
+}
+```

--- a/octets_rev/src/lib.rs
+++ b/octets_rev/src/lib.rs
@@ -24,7 +24,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use likely_stable::if_unlikely;
+use branches::unlikely;
 /// Zero-copy abstraction for parsing and constructing network packets.
 use std::mem;
 use std::ops::Deref;
@@ -101,14 +101,14 @@ macro_rules! get_u {
 
 macro_rules! peek_u_reverse {
     ($b:expr, $ty:ty , $len:expr) => {{
-        if_unlikely! { $b.off < $len => {
-            return Err (BufferError::BufferProtocolError);
+        if unlikely($b.off < $len) {
+            return Err(BufferError::BufferProtocolError);
         } else {
             $b.off -= $len;
             let out = peek_u_buflen_guaranteed!($b, $ty, $len);
             $b.off += $len;
             return out;
-        }};
+        }
     }};
 }
 
@@ -121,13 +121,13 @@ macro_rules! peek_u_reverse {
 /// the set of [..]() functions.
 macro_rules! get_u_reverse {
     ($b:expr, $ty:ty, $len:expr) => {{
-        if_unlikely! { $b.off < $len => {
-            return Err (BufferError::BufferProtocolError);
+        if unlikely($b.off < $len) {
+            return Err(BufferError::BufferProtocolError);
         } else {
             $b.off -= $len;
             let out = peek_u_buflen_guaranteed!($b, $ty, $len);
             return out;
-        }};
+        }
     }};
 }
 
@@ -822,32 +822,35 @@ impl<'a> OctetsRev<'a> {
     /// Reads an unsigned variable-length integer in network byte-order from
     /// the current offset and rewinds the buffer.
     pub fn get_varint(&mut self) -> Result<u64> {
-        if_unlikely! { self.off == 0 => {
+        if unlikely(self.off == 0) {
             Err(BufferError::BufferProtocolError)
         } else {
             let last = self.peek_u8()?;
             let len = varint_parse_len_reverse(last);
             let out = match len {
                 1 => u64::from(self.get_u8()? >> 2),
-                2 => u64::from(self.get_u16() ? >> 2),
+                2 => u64::from(self.get_u16()? >> 2),
                 4 => u64::from(self.get_u32()? >> 2),
                 8 => self.get_u64()? >> 2,
                 _ => unreachable!(),
             };
             Ok(out)
-        }}
+        }
     }
 
     /// Rewind the buffer of  `len` bytes from the current offset and then
     /// read without copying.
     pub fn get_bytes(&mut self, len: usize) -> Result<Octets<'a>> {
-        if_unlikely! { self.off < len => {
+        if unlikely(self.off < len) {
             Err(BufferError::BufferProtocolError)
         } else {
             self.off -= len;
-            let out = Octets {buf: &self.buf[self.off..self.off + len], off: 0};
+            let out = Octets {
+                buf: &self.buf[self.off..self.off + len],
+                off: 0,
+            };
             Ok(out)
-        }}
+        }
     }
 
     /// Rewind the buffer of `len` bytes and read `len` bytes  without copying.

--- a/octets_rev/src/lib.rs
+++ b/octets_rev/src/lib.rs
@@ -644,7 +644,7 @@ impl<'a> OctetsMut<'a> {
 
     /// Rewinds the buffer's offset.
     pub fn rewind(&mut self, rewind: usize) -> Result<()> {
-        if self.off < rewind {
+        if rewind > self.off {
             return Err(BufferError::BufferTooShortError);
         }
         self.off -= rewind;
@@ -896,7 +896,7 @@ impl<'a> OctetsRev<'a> {
     /// Rewinds the buffer's offset, moving the offset towards
     /// higher values.
     pub fn rewind(&mut self, rewind: usize) -> Result<()> {
-        if self.off < rewind {
+        if rewind > self.buf.len() - self.off {
             return Err(BufferError::BufferTooShortError);
         }
         self.off += rewind;
@@ -1066,7 +1066,7 @@ impl<'a> OctetsMutRev<'a> {
 
     /// Rewinds the buffer, moving the offet towards higher values.
     pub fn rewind(&mut self, rewind: usize) -> Result<()> {
-        if self.off < rewind {
+        if rewind > self.buf.len() - self.off {
             return Err(BufferError::BufferTooShortError);
         }
         self.off += rewind;
@@ -1436,67 +1436,67 @@ impl OctetsWrite for OctetsMut<'_> {
 
 impl OctetsWrite for Box<dyn OctetsWrite + '_> {
     fn put_u8(&mut self, v: u8) -> Result<&mut [u8]> {
-        <dyn OctetsWrite>::put_u8(self, v)
+        (**self).put_u8(v)
     }
 
     fn put_u16(&mut self, v: u16) -> Result<&mut [u8]> {
-        <dyn OctetsWrite>::put_u16(self, v)
+        (**self).put_u16(v)
     }
 
     fn put_u24(&mut self, v: u32) -> Result<&mut [u8]> {
-        <dyn OctetsWrite>::put_u24(self, v)
+        (**self).put_u24(v)
     }
 
     fn put_u32(&mut self, v: u32) -> Result<&mut [u8]> {
-        <dyn OctetsWrite>::put_u32(self, v)
+        (**self).put_u32(v)
     }
 
     fn put_u64(&mut self, v: u64) -> Result<&mut [u8]> {
-        <dyn OctetsWrite>::put_u64(self, v)
+        (**self).put_u64(v)
     }
 
     fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
-        <dyn OctetsWrite>::put_bytes(self, v)
+        (**self).put_bytes(v)
     }
 
     fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
-        <dyn OctetsWrite>::put_varint(self, v)
+        (**self).put_varint(v)
     }
 
     fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]> {
-        <dyn OctetsWrite>::put_varint_with_len(self, v, len)
+        (**self).put_varint_with_len(v, len)
     }
 
     fn cap(&self) -> usize {
-        <dyn OctetsWrite>::cap(self)
+        (**self).cap()
     }
 
     fn len(&self) -> usize {
-        <dyn OctetsWrite>::len(self)
+        (**self).len()
     }
 
     fn off(&self) -> usize {
-        <dyn OctetsWrite>::off(self)
+        (**self).off()
     }
 
     fn buf(&self) -> &[u8] {
-        <dyn OctetsWrite>::buf(self)
+        (**self).buf()
     }
 
     fn skip(&mut self, skip: usize) -> Result<()> {
-        <dyn OctetsWrite>::skip(self, skip)
+        (**self).skip(skip)
     }
 
     fn rewind(&mut self, rewind: usize) -> Result<()> {
-        <dyn OctetsWrite>::rewind(self, rewind)
+        (**self).rewind(rewind)
     }
 
     fn to_vec(&self) -> Vec<u8> {
-        <dyn OctetsWrite>::to_vec(self)
+        (**self).to_vec()
     }
 
     fn is_empty(&self) -> bool {
-        <dyn OctetsWrite>::is_empty(self)
+        (**self).is_empty()
     }
 }
 
@@ -1504,83 +1504,83 @@ impl<'a> OctetsRead for Box<dyn OctetsRead<Bytes = Octets<'a>> + '_> {
     type Bytes = Octets<'a>;
 
     fn get_u8(&mut self) -> Result<u8> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::get_u8(self)
+        (**self).get_u8()
     }
 
     fn get_u16(&mut self) -> Result<u16> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::get_u16(self)
+        (**self).get_u16()
     }
 
     fn get_u24(&mut self) -> Result<u32> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::get_u24(self)
+        (**self).get_u24()
     }
 
     fn get_u32(&mut self) -> Result<u32> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::get_u32(self)
+        (**self).get_u32()
     }
 
     fn get_u64(&mut self) -> Result<u64> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::get_u64(self)
+        (**self).get_u64()
     }
 
     fn peek_u8(&mut self) -> Result<u8> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::peek_u8(self)
+        (**self).peek_u8()
     }
 
     fn get_bytes(&mut self, len: usize) -> Result<Self::Bytes> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::get_bytes(self, len)
+        (**self).get_bytes(len)
     }
 
     fn get_varint(&mut self) -> Result<u64> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::get_varint(self)
+        (**self).get_varint()
     }
 
     fn get_bytes_with_u8_length(&mut self) -> Result<Self::Bytes> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::get_bytes_with_u8_length(self)
+        (**self).get_bytes_with_u8_length()
     }
 
     fn get_bytes_with_u16_length(&mut self) -> Result<Self::Bytes> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::get_bytes_with_u16_length(self)
+        (**self).get_bytes_with_u16_length()
     }
 
     fn get_bytes_with_varint_length(&mut self) -> Result<Self::Bytes> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::get_bytes_with_varint_length(self)
+        (**self).get_bytes_with_varint_length()
     }
 
     fn is_empty(&self) -> bool {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::is_empty(self)
+        (**self).is_empty()
     }
 
     fn to_vec(&self) -> Vec<u8> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::to_vec(self)
+        (**self).to_vec()
     }
 
     fn rewind(&mut self, rewind: usize) -> Result<()> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::rewind(self, rewind)
+        (**self).rewind(rewind)
     }
 
     fn skip(&mut self, skip: usize) -> Result<()> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::skip(self, skip)
+        (**self).skip(skip)
     }
 
     fn buf(&self) -> &[u8] {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::buf(self)
+        (**self).buf()
     }
 
     fn off(&self) -> usize {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::off(self)
+        (**self).off()
     }
 
     fn len(&self) -> usize {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::len(self)
+        (**self).len()
     }
 
     fn cap(&self) -> usize {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::cap(self)
+        (**self).cap()
     }
 
     fn peek_bytes(&mut self, len: usize) -> Result<Self::Bytes> {
-        <dyn OctetsRead<Bytes = Octets<'_>>>::peek_bytes(self, len)
+        (**self).peek_bytes(len)
     }
 }
 

--- a/octets_rev/src/lib.rs
+++ b/octets_rev/src/lib.rs
@@ -1297,7 +1297,6 @@ impl<'a> OctetsRead for OctetsRev<'a> {
 
     #[inline]
     fn peek_bytes(&mut self, len: usize) -> Result<Self::Bytes> {
-        // OctetsRev doesn't have peek_bytes implemented yet.
         // Let's implement it by rewinding and then advancing back.
         if self.off < len {
             return Err(BufferError::BufferTooShortError);

--- a/octets_rev/src/lib.rs
+++ b/octets_rev/src/lib.rs
@@ -934,6 +934,26 @@ impl<'a> std::ops::Deref for OctetsRev<'a> {
     }
 }
 
+impl<'a> From<Octets<'a>> for OctetsRev<'a> {
+    /// Convert from forward to backward direction
+    fn from(value: Octets<'a>) -> Self {
+        OctetsRev {
+            buf: value.buf,
+            off: value.off,
+        }
+    }
+}
+
+impl<'a> From<OctetsRev<'a>> for Octets<'a> {
+    /// Convert from backward to forward direction
+    fn from(value: OctetsRev<'a>) -> Self {
+        Octets {
+            buf: value.buf,
+            off: value.off,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct OctetsMutRev<'a> {
     buf: &'a mut [u8],
@@ -1073,6 +1093,24 @@ impl<'a> AsRef<[u8]> for OctetsMutRev<'a> {
 impl<'a> AsMut<[u8]> for OctetsMutRev<'a> {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.buf[..self.off]
+    }
+}
+
+impl<'a> From<OctetsMut<'a>> for OctetsMutRev<'a> {
+    fn from(value: OctetsMut<'a>) -> Self {
+        OctetsMutRev {
+            buf: value.buf,
+            off: value.off,
+        }
+    }
+}
+
+impl<'a> From<OctetsMutRev<'a>> for OctetsMut<'a> {
+    fn from(value: OctetsMutRev<'a>) -> Self {
+        OctetsMut {
+            buf: value.buf,
+            off: value.off,
+        }
     }
 }
 

--- a/octets_rev/src/lib.rs
+++ b/octets_rev/src/lib.rs
@@ -508,7 +508,7 @@ impl<'a> OctetsMut<'a> {
                 buf[0] |= 0xc0;
                 buf
             },
-            _ => panic!("value is too large for varint"),
+            _ => panic!("BUG: value is too large for varint"),
         };
         Ok(buf)
     }
@@ -589,8 +589,7 @@ impl<'a> OctetsMut<'a> {
         Ok(out)
     }
 
-    /// Writes `len` bytes from the current offset without copying and advances
-    /// the buffer.
+    /// Writes `len` bytes to the current offset by copy offset and advances the buffer.
     pub fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
         let len = v.len();
         if self.cap() < len {
@@ -677,6 +676,10 @@ impl<'a> OctetsMut<'a> {
         self.buf
     }
 
+    pub fn buf_mut(&mut self) -> &mut [u8] {
+        self.buf
+    }
+
     /// Copies the buffer from the current offset into a new `Vec<u8>`.
     pub fn to_vec(&self) -> Vec<u8> {
         self.as_ref().to_vec()
@@ -733,8 +736,8 @@ pub const fn varint_parse_len_reverse(last: u8) -> usize {
     }
 }
 
-pub trait OctetsRead<'a> {
-    type Bytes;
+pub trait OctetsRead {
+    type Bytes: AsRef<[u8]>;
 
     fn get_u8(&mut self) -> Result<u8>;
     fn get_u16(&mut self) -> Result<u16>;
@@ -747,18 +750,25 @@ pub trait OctetsRead<'a> {
     fn get_bytes_with_u16_length(&mut self) -> Result<Self::Bytes>;
     fn get_bytes_with_varint_length(&mut self) -> Result<Self::Bytes>;
     fn peek_u8(&mut self) -> Result<u8>;
+    fn peek_bytes(&mut self, len: usize) -> Result<Self::Bytes>;
     fn skip(&mut self, skip: usize) -> Result<()>;
     fn rewind(&mut self, rewind: usize) -> Result<()>;
     fn cap(&self) -> usize;
     fn len(&self) -> usize;
     fn is_empty(&self) -> bool;
     fn off(&self) -> usize;
-    fn buf(&self) -> &'a [u8];
+    fn buf(&self) -> &[u8];
     fn to_vec(&self) -> Vec<u8>;
 }
-pub trait OctetsWrite<'a> {
+pub trait OctetsWrite {
     fn put_varint(&mut self, v: u64) -> Result<&mut [u8]>;
     fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]>;
+    fn put_u8(&mut self, v: u8) -> Result<&mut [u8]>;
+    fn put_u16(&mut self, v: u16) -> Result<&mut [u8]>;
+    fn put_u24(&mut self, v: u32) -> Result<&mut [u8]>;
+    fn put_u32(&mut self, v: u32) -> Result<&mut [u8]>;
+    fn put_u64(&mut self, v: u64) -> Result<&mut [u8]>;
+    fn put_bytes(&mut self, v: &[u8]) -> Result<()>;
     fn skip(&mut self, skip: usize) -> Result<()>;
     fn rewind(&mut self, rewind: usize) -> Result<()>;
     fn cap(&self) -> usize;
@@ -817,7 +827,7 @@ impl<'a> OctetsRev<'a> {
     }
 
     /// In reversed buffers, variable length integers also need to be
-    /// "reversed", with the 2-bits length indicator at the end of the first
+    /// reversed, with the 2-bits length indicator at the end of the first
     /// byte in the backward direction.
     /// Reads an unsigned variable-length integer in network byte-order from
     /// the current offset and rewinds the buffer.
@@ -969,8 +979,13 @@ impl<'a> OctetsMutRev<'a> {
         OctetsMutRev { buf, off: len }
     }
 
-    /// Writes an unsigned 8-bit integer at the current offset and advances
-    /// the buffer.
+    pub fn from_octetsmut(o: OctetsMut<'a>) -> Self {
+        let off = o.off();
+        OctetsMutRev { buf: o.buf, off }
+    }
+
+    /// Advance the buffer by 1 bytes (decreasing its offset) and
+    /// then write 1 byte at the current offset.
     pub fn put_u8(&mut self, v: u8) -> Result<&mut [u8]> {
         put_u_reverse!(self, u8, v, 1)
     }
@@ -995,6 +1010,7 @@ impl<'a> OctetsMutRev<'a> {
     pub fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
         self.put_varint_with_len(v, varint_len(v))
     }
+
     #[inline]
     pub fn put_varint_with_len(
         &mut self, v: u64, len: usize,
@@ -1019,13 +1035,13 @@ impl<'a> OctetsMutRev<'a> {
                 buf[7] |= 0x3;
                 buf
             },
-            _ => panic!("value is too large for varint"),
+            _ => unimplemented!(),
         };
         Ok(buf)
     }
 
-    /// Writes `len` bytes from the current offset without copying and advances
-    /// the buffer.
+    /// Advance the buffer by decreasing the offset of `len` and then Writes `len` bytes
+    /// by copy at the decreased offset value.
     pub fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
         let len = v.len();
         if self.cap() < len {
@@ -1117,7 +1133,7 @@ impl<'a> From<OctetsMutRev<'a>> for OctetsMut<'a> {
     }
 }
 
-impl<'a> OctetsRead<'a> for Octets<'a> {
+impl<'a> OctetsRead for Octets<'a> {
     type Bytes = Octets<'a>;
 
     #[inline]
@@ -1176,6 +1192,11 @@ impl<'a> OctetsRead<'a> for Octets<'a> {
     }
 
     #[inline]
+    fn peek_bytes(&mut self, len: usize) -> Result<Self::Bytes> {
+        Octets::peek_bytes(self, len)
+    }
+
+    #[inline]
     fn skip(&mut self, skip: usize) -> Result<()> {
         Octets::skip(self, skip)
     }
@@ -1216,7 +1237,7 @@ impl<'a> OctetsRead<'a> for Octets<'a> {
     }
 }
 
-impl<'a> OctetsRead<'a> for OctetsRev<'a> {
+impl<'a> OctetsRead for OctetsRev<'a> {
     type Bytes = Octets<'a>;
 
     #[inline]
@@ -1275,6 +1296,22 @@ impl<'a> OctetsRead<'a> for OctetsRev<'a> {
     }
 
     #[inline]
+    fn peek_bytes(&mut self, len: usize) -> Result<Self::Bytes> {
+        // OctetsRev doesn't have peek_bytes implemented yet.
+        // Let's implement it by rewinding and then advancing back.
+        if self.off < len {
+            return Err(BufferError::BufferTooShortError);
+        }
+        self.off -= len;
+        let out = Octets {
+            buf: &self.buf[self.off..self.off + len],
+            off: 0,
+        };
+        self.off += len;
+        Ok(out)
+    }
+
+    #[inline]
     fn skip(&mut self, skip: usize) -> Result<()> {
         OctetsRev::skip(self, skip)
     }
@@ -1315,15 +1352,45 @@ impl<'a> OctetsRead<'a> for OctetsRev<'a> {
     }
 }
 
-impl<'a> OctetsWrite<'a> for OctetsMut<'a> {
+impl OctetsWrite for OctetsMut<'_> {
     #[inline]
     fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
-        OctetsMut::put_varint(self, v)
+        self.put_varint(v)
     }
 
     #[inline]
     fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]> {
-        OctetsMut::put_varint_with_len(self, v, len)
+        self.put_varint_with_len(v, len)
+    }
+
+    #[inline]
+    fn put_u8(&mut self, v: u8) -> Result<&mut [u8]> {
+        self.put_u8(v)
+    }
+
+    #[inline]
+    fn put_u16(&mut self, v: u16) -> Result<&mut [u8]> {
+        self.put_u16(v)
+    }
+
+    #[inline]
+    fn put_u24(&mut self, v: u32) -> Result<&mut [u8]> {
+        self.put_u24(v)
+    }
+
+    #[inline]
+    fn put_u32(&mut self, v: u32) -> Result<&mut [u8]> {
+        self.put_u32(v)
+    }
+
+    #[inline]
+    fn put_u64(&mut self, v: u64) -> Result<&mut [u8]> {
+        self.put_u64(v)
+    }
+
+    #[inline]
+    fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
+        self.put_bytes(v)
     }
 
     #[inline]
@@ -1367,55 +1434,235 @@ impl<'a> OctetsWrite<'a> for OctetsMut<'a> {
     }
 }
 
-impl<'a> OctetsWrite<'a> for OctetsMutRev<'a> {
+impl OctetsWrite for Box<dyn OctetsWrite + '_> {
+    fn put_u8(&mut self, v: u8) -> Result<&mut [u8]> {
+        <dyn OctetsWrite>::put_u8(self, v)
+    }
+
+    fn put_u16(&mut self, v: u16) -> Result<&mut [u8]> {
+        <dyn OctetsWrite>::put_u16(self, v)
+    }
+
+    fn put_u24(&mut self, v: u32) -> Result<&mut [u8]> {
+        <dyn OctetsWrite>::put_u24(self, v)
+    }
+
+    fn put_u32(&mut self, v: u32) -> Result<&mut [u8]> {
+        <dyn OctetsWrite>::put_u32(self, v)
+    }
+
+    fn put_u64(&mut self, v: u64) -> Result<&mut [u8]> {
+        <dyn OctetsWrite>::put_u64(self, v)
+    }
+
+    fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
+        <dyn OctetsWrite>::put_bytes(self, v)
+    }
+
+    fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
+        <dyn OctetsWrite>::put_varint(self, v)
+    }
+
+    fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]> {
+        <dyn OctetsWrite>::put_varint_with_len(self, v, len)
+    }
+
+    fn cap(&self) -> usize {
+        <dyn OctetsWrite>::cap(self)
+    }
+
+    fn len(&self) -> usize {
+        <dyn OctetsWrite>::len(self)
+    }
+
+    fn off(&self) -> usize {
+        <dyn OctetsWrite>::off(self)
+    }
+
+    fn buf(&self) -> &[u8] {
+        <dyn OctetsWrite>::buf(self)
+    }
+
+    fn skip(&mut self, skip: usize) -> Result<()> {
+        <dyn OctetsWrite>::skip(self, skip)
+    }
+
+    fn rewind(&mut self, rewind: usize) -> Result<()> {
+        <dyn OctetsWrite>::rewind(self, rewind)
+    }
+
+    fn to_vec(&self) -> Vec<u8> {
+        <dyn OctetsWrite>::to_vec(self)
+    }
+
+    fn is_empty(&self) -> bool {
+        <dyn OctetsWrite>::is_empty(self)
+    }
+}
+
+impl<'a> OctetsRead for Box<dyn OctetsRead<Bytes = Octets<'a>> + '_> {
+    type Bytes = Octets<'a>;
+
+    fn get_u8(&mut self) -> Result<u8> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::get_u8(self)
+    }
+
+    fn get_u16(&mut self) -> Result<u16> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::get_u16(self)
+    }
+
+    fn get_u24(&mut self) -> Result<u32> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::get_u24(self)
+    }
+
+    fn get_u32(&mut self) -> Result<u32> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::get_u32(self)
+    }
+
+    fn get_u64(&mut self) -> Result<u64> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::get_u64(self)
+    }
+
+    fn peek_u8(&mut self) -> Result<u8> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::peek_u8(self)
+    }
+
+    fn get_bytes(&mut self, len: usize) -> Result<Self::Bytes> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::get_bytes(self, len)
+    }
+
+    fn get_varint(&mut self) -> Result<u64> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::get_varint(self)
+    }
+
+    fn get_bytes_with_u8_length(&mut self) -> Result<Self::Bytes> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::get_bytes_with_u8_length(self)
+    }
+
+    fn get_bytes_with_u16_length(&mut self) -> Result<Self::Bytes> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::get_bytes_with_u16_length(self)
+    }
+
+    fn get_bytes_with_varint_length(&mut self) -> Result<Self::Bytes> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::get_bytes_with_varint_length(self)
+    }
+
+    fn is_empty(&self) -> bool {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::is_empty(self)
+    }
+
+    fn to_vec(&self) -> Vec<u8> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::to_vec(self)
+    }
+
+    fn rewind(&mut self, rewind: usize) -> Result<()> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::rewind(self, rewind)
+    }
+
+    fn skip(&mut self, skip: usize) -> Result<()> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::skip(self, skip)
+    }
+
+    fn buf(&self) -> &[u8] {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::buf(self)
+    }
+
+    fn off(&self) -> usize {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::off(self)
+    }
+
+    fn len(&self) -> usize {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::len(self)
+    }
+
+    fn cap(&self) -> usize {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::cap(self)
+    }
+
+    fn peek_bytes(&mut self, len: usize) -> Result<Self::Bytes> {
+        <dyn OctetsRead<Bytes = Octets<'_>>>::peek_bytes(self, len)
+    }
+}
+
+impl OctetsWrite for OctetsMutRev<'_> {
     #[inline]
     fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
-        OctetsMutRev::put_varint(self, v)
+        self.put_varint(v)
+    }
+
+    #[inline]
+    fn put_u8(&mut self, v: u8) -> Result<&mut [u8]> {
+        self.put_u8(v)
+    }
+
+    #[inline]
+    fn put_u16(&mut self, v: u16) -> Result<&mut [u8]> {
+        self.put_u16(v)
+    }
+
+    #[inline]
+    fn put_u24(&mut self, v: u32) -> Result<&mut [u8]> {
+        self.put_u24(v)
+    }
+
+    #[inline]
+    fn put_u32(&mut self, v: u32) -> Result<&mut [u8]> {
+        self.put_u32(v)
+    }
+
+    #[inline]
+    fn put_u64(&mut self, v: u64) -> Result<&mut [u8]> {
+        self.put_u64(v)
     }
 
     #[inline]
     fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]> {
-        OctetsMutRev::put_varint_with_len(self, v, len)
+        self.put_varint_with_len(v, len)
+    }
+
+    #[inline]
+    fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
+        self.put_bytes(v)
     }
 
     #[inline]
     fn skip(&mut self, skip: usize) -> Result<()> {
-        OctetsMutRev::skip(self, skip)
+        self.skip(skip)
     }
 
     #[inline]
     fn rewind(&mut self, rewind: usize) -> Result<()> {
-        OctetsMutRev::rewind(self, rewind)
+        self.rewind(rewind)
     }
 
     #[inline]
     fn cap(&self) -> usize {
-        OctetsMutRev::cap(self)
+        self.cap()
     }
 
     #[inline]
     fn len(&self) -> usize {
-        OctetsMutRev::len(self)
+        self.len()
     }
 
     #[inline]
     fn is_empty(&self) -> bool {
-        OctetsMutRev::is_empty(self)
+        self.is_empty()
     }
 
     #[inline]
     fn off(&self) -> usize {
-        OctetsMutRev::off(self)
+        self.off()
     }
 
     #[inline]
     fn buf(&self) -> &[u8] {
-        OctetsMutRev::buf(self)
+        self.buf()
     }
 
     #[inline]
     fn to_vec(&self) -> Vec<u8> {
-        OctetsMutRev::to_vec(self)
+        self.to_vec()
     }
 }
 
@@ -1789,184 +2036,5 @@ mod tests {
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         ];
         assert_eq!(&d, &exp);
-    }
-
-    #[test]
-    fn put_bytes() {
-        let mut d = [0; 5];
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            assert_eq!(b.cap(), 5);
-            assert_eq!(b.off(), 0);
-            let p = [0x0a, 0x0b, 0x0c, 0x0d, 0x0e];
-            assert!(b.put_bytes(&p).is_ok());
-            assert_eq!(b.cap(), 0);
-            assert_eq!(b.off(), 5);
-            assert!(b.put_u8(1).is_err());
-        }
-        let exp = [0xa, 0xb, 0xc, 0xd, 0xe];
-        assert_eq!(&d, &exp);
-    }
-
-    #[test]
-    fn split() {
-        let mut d = b"helloworld".to_vec();
-        let mut b = OctetsMut::with_slice(&mut d);
-        assert_eq!(b.cap(), 10);
-        assert_eq!(b.off(), 0);
-        assert_eq!(b.as_ref(), b"helloworld");
-        assert!(b.get_bytes(5).is_ok());
-        assert_eq!(b.cap(), 5);
-        assert_eq!(b.off(), 5);
-        assert_eq!(b.as_ref(), b"world");
-        let off = b.off();
-        let (first, last) = b.split_at(off).unwrap();
-        assert_eq!(first.cap(), 5);
-        assert_eq!(first.off(), 0);
-        assert_eq!(first.as_ref(), b"hello");
-        assert_eq!(last.cap(), 5);
-        assert_eq!(last.off(), 0);
-        assert_eq!(last.as_ref(), b"world");
-    }
-
-    #[test]
-    fn split_at() {
-        let mut d = b"helloworld".to_vec();
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            let (first, second) = b.split_at(5).unwrap();
-            let mut exp1 = b"hello".to_vec();
-            assert_eq!(first.as_ref(), &mut exp1[..]);
-            let mut exp2 = b"world".to_vec();
-            assert_eq!(second.as_ref(), &mut exp2[..]);
-        }
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            let (first, second) = b.split_at(10).unwrap();
-            let mut exp1 = b"helloworld".to_vec();
-            assert_eq!(first.as_ref(), &mut exp1[..]);
-            let mut exp2 = b"".to_vec();
-            assert_eq!(second.as_ref(), &mut exp2[..]);
-        }
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            let (first, second) = b.split_at(9).unwrap();
-            let mut exp1 = b"helloworl".to_vec();
-            assert_eq!(first.as_ref(), &mut exp1[..]);
-            let mut exp2 = b"d".to_vec();
-            assert_eq!(second.as_ref(), &mut exp2[..]);
-        }
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            assert!(b.split_at(11).is_err());
-        }
-    }
-
-    #[test]
-    fn slice() {
-        let d = b"helloworld".to_vec();
-        {
-            let b = Octets::with_slice(&d);
-            let exp = b"hello".to_vec();
-            assert_eq!(b.slice(5), Ok(&exp[..]));
-        }
-        {
-            let b = Octets::with_slice(&d);
-            let exp = b"".to_vec();
-            assert_eq!(b.slice(0), Ok(&exp[..]));
-        }
-        {
-            let mut b = Octets::with_slice(&d);
-            b.get_bytes(5).unwrap();
-            let exp = b"world".to_vec();
-            assert_eq!(b.slice(5), Ok(&exp[..]));
-        }
-        {
-            let b = Octets::with_slice(&d);
-            assert!(b.slice(11).is_err());
-        }
-    }
-
-    #[test]
-    fn slice_mut() {
-        let mut d = b"helloworld".to_vec();
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            let mut exp = b"hello".to_vec();
-            assert_eq!(b.slice(5), Ok(&mut exp[..]));
-        }
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            let mut exp = b"".to_vec();
-            assert_eq!(b.slice(0), Ok(&mut exp[..]));
-        }
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            b.get_bytes(5).unwrap();
-            let mut exp = b"world".to_vec();
-            assert_eq!(b.slice(5), Ok(&mut exp[..]));
-        }
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            assert!(b.slice(11).is_err());
-        }
-    }
-
-    #[test]
-    fn slice_last() {
-        let d = b"helloworld".to_vec();
-        {
-            let b = Octets::with_slice(&d);
-            let exp = b"orld".to_vec();
-            assert_eq!(b.slice_last(4), Ok(&exp[..]));
-        }
-        {
-            let b = Octets::with_slice(&d);
-            let exp = b"d".to_vec();
-            assert_eq!(b.slice_last(1), Ok(&exp[..]));
-        }
-        {
-            let b = Octets::with_slice(&d);
-            let exp = b"".to_vec();
-            assert_eq!(b.slice_last(0), Ok(&exp[..]));
-        }
-        {
-            let b = Octets::with_slice(&d);
-            let exp = b"helloworld".to_vec();
-            assert_eq!(b.slice_last(10), Ok(&exp[..]));
-        }
-        {
-            let b = Octets::with_slice(&d);
-            assert!(b.slice_last(11).is_err());
-        }
-    }
-
-    #[test]
-    fn slice_last_mut() {
-        let mut d = b"helloworld".to_vec();
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            let mut exp = b"orld".to_vec();
-            assert_eq!(b.slice_last(4), Ok(&mut exp[..]));
-        }
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            let mut exp = b"d".to_vec();
-            assert_eq!(b.slice_last(1), Ok(&mut exp[..]));
-        }
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            let mut exp = b"".to_vec();
-            assert_eq!(b.slice_last(0), Ok(&mut exp[..]));
-        }
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            let mut exp = b"helloworld".to_vec();
-            assert_eq!(b.slice_last(10), Ok(&mut exp[..]));
-        }
-        {
-            let mut b = OctetsMut::with_slice(&mut d);
-            assert!(b.slice_last(11).is_err());
-        }
     }
 }

--- a/octets_rev/src/lib.rs
+++ b/octets_rev/src/lib.rs
@@ -422,8 +422,8 @@ impl<'a> Octets<'a> {
         if len > self.cap() {
             return Err(BufferError::BufferTooShortError);
         }
-        let cap = self.cap();
-        Ok(&self.buf[cap - len..])
+        let end = self.buf.len();
+        Ok(&self.buf[end - len..end])
     }
 
     /// Advances the buffer's offset.
@@ -742,8 +742,8 @@ impl<'a> OctetsMut<'a> {
         if len > self.cap() {
             return Err(BufferError::BufferTooShortError);
         }
-        let cap = self.cap();
-        Ok(&mut self.buf[cap - len..])
+        let end = self.buf.len();
+        Ok(&mut self.buf[end - len..end])
     }
 
     /// Advances the buffer's offset.
@@ -914,6 +914,12 @@ pub trait OctetsRead {
 
     /// Returns a reference to the internal buffer.
     fn buf(&self) -> &[u8];
+
+    /// Returns a slice of `len` elements from the current offset.
+    fn slice(&self, len: usize) -> Result<&[u8]>;
+
+    /// Returns a slice of `len` elements from the end of the buffer.
+    fn slice_last(&self, len: usize) -> Result<&[u8]>;
 
     /// Copies the buffer from the current offset into a new `Vec<u8>`.
     fn to_vec(&self) -> Vec<u8>;
@@ -1139,6 +1145,22 @@ impl<'a> OctetsRev<'a> {
     pub fn to_vec(&self) -> Vec<u8> {
         self.as_ref().to_vec()
     }
+
+    /// Returns a slice of `len` elements from the current offset (moving backwards).
+    pub fn slice(&self, len: usize) -> Result<&'a [u8]> {
+        if len > self.cap() {
+            return Err(BufferError::BufferTooShortError);
+        }
+        Ok(&self.buf[self.off - len..self.off])
+    }
+
+    /// Returns a slice of `len` elements from the beginning of the buffer.
+    pub fn slice_last(&self, len: usize) -> Result<&'a [u8]> {
+        if len > self.cap() {
+            return Err(BufferError::BufferTooShortError);
+        }
+        Ok(&self.buf[..len])
+    }
 }
 
 impl<'a> AsRef<[u8]> for OctetsRev<'a> {
@@ -1328,6 +1350,22 @@ impl<'a> OctetsMutRev<'a> {
     pub fn to_vec(&self) -> Vec<u8> {
         self.as_ref().to_vec()
     }
+
+    /// Returns a slice of `len` elements from the current offset (moving backwards).
+    pub fn slice(&'a mut self, len: usize) -> Result<&'a mut [u8]> {
+        if len > self.cap() {
+            return Err(BufferError::BufferTooShortError);
+        }
+        Ok(&mut self.buf[self.off - len..self.off])
+    }
+
+    /// Returns a slice of `len` elements from the beginning of the buffer.
+    pub fn slice_last(&'a mut self, len: usize) -> Result<&'a mut [u8]> {
+        if len > self.cap() {
+            return Err(BufferError::BufferTooShortError);
+        }
+        Ok(&mut self.buf[..len])
+    }
 }
 
 impl<'a> AsRef<[u8]> for OctetsMutRev<'a> {
@@ -1454,8 +1492,18 @@ impl<'a> OctetsRead for Octets<'a> {
     }
 
     #[inline]
-    fn buf(&self) -> &'a [u8] {
+    fn buf(&self) -> &[u8] {
         Octets::buf(self)
+    }
+
+    #[inline]
+    fn slice(&self, len: usize) -> Result<&[u8]> {
+        Octets::slice(self, len)
+    }
+
+    #[inline]
+    fn slice_last(&self, len: usize) -> Result<&[u8]> {
+        Octets::slice_last(self, len)
     }
 
     #[inline]
@@ -1568,8 +1616,18 @@ impl<'a> OctetsRead for OctetsRev<'a> {
     }
 
     #[inline]
-    fn buf(&self) -> &'a [u8] {
+    fn buf(&self) -> &[u8] {
         OctetsRev::buf(self)
+    }
+
+    #[inline]
+    fn slice(&self, len: usize) -> Result<&[u8]> {
+        OctetsRev::slice(self, len)
+    }
+
+    #[inline]
+    fn slice_last(&self, len: usize) -> Result<&[u8]> {
+        OctetsRev::slice_last(self, len)
     }
 
     #[inline]
@@ -1581,42 +1639,42 @@ impl<'a> OctetsRead for OctetsRev<'a> {
 impl OctetsWrite for OctetsMut<'_> {
     #[inline]
     fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
-        self.put_varint(v)
+        OctetsMut::put_varint(self, v)
     }
 
     #[inline]
     fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]> {
-        self.put_varint_with_len(v, len)
+        OctetsMut::put_varint_with_len(self, v, len)
     }
 
     #[inline]
     fn put_u8(&mut self, v: u8) -> Result<&mut [u8]> {
-        self.put_u8(v)
+        OctetsMut::put_u8(self, v)
     }
 
     #[inline]
     fn put_u16(&mut self, v: u16) -> Result<&mut [u8]> {
-        self.put_u16(v)
+        OctetsMut::put_u16(self, v)
     }
 
     #[inline]
     fn put_u24(&mut self, v: u32) -> Result<&mut [u8]> {
-        self.put_u24(v)
+        OctetsMut::put_u24(self, v)
     }
 
     #[inline]
     fn put_u32(&mut self, v: u32) -> Result<&mut [u8]> {
-        self.put_u32(v)
+        OctetsMut::put_u32(self, v)
     }
 
     #[inline]
     fn put_u64(&mut self, v: u64) -> Result<&mut [u8]> {
-        self.put_u64(v)
+        OctetsMut::put_u64(self, v)
     }
 
     #[inline]
     fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
-        self.put_bytes(v)
+        OctetsMut::put_bytes(self, v)
     }
 
     #[inline]
@@ -1793,6 +1851,14 @@ impl<'a> OctetsRead for Box<dyn OctetsRead<Bytes = Octets<'a>> + '_> {
         (**self).buf()
     }
 
+    fn slice(&self, len: usize) -> Result<&[u8]> {
+        (**self).slice(len)
+    }
+
+    fn slice_last(&self, len: usize) -> Result<&[u8]> {
+        (**self).slice_last(len)
+    }
+
     fn off(&self) -> usize {
         (**self).off()
     }
@@ -1813,82 +1879,82 @@ impl<'a> OctetsRead for Box<dyn OctetsRead<Bytes = Octets<'a>> + '_> {
 impl OctetsWrite for OctetsMutRev<'_> {
     #[inline]
     fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
-        self.put_varint(v)
+        OctetsMutRev::put_varint(self, v)
     }
 
     #[inline]
     fn put_u8(&mut self, v: u8) -> Result<&mut [u8]> {
-        self.put_u8(v)
+        OctetsMutRev::put_u8(self, v)
     }
 
     #[inline]
     fn put_u16(&mut self, v: u16) -> Result<&mut [u8]> {
-        self.put_u16(v)
+        OctetsMutRev::put_u16(self, v)
     }
 
     #[inline]
     fn put_u24(&mut self, v: u32) -> Result<&mut [u8]> {
-        self.put_u24(v)
+        OctetsMutRev::put_u24(self, v)
     }
 
     #[inline]
     fn put_u32(&mut self, v: u32) -> Result<&mut [u8]> {
-        self.put_u32(v)
+        OctetsMutRev::put_u32(self, v)
     }
 
     #[inline]
     fn put_u64(&mut self, v: u64) -> Result<&mut [u8]> {
-        self.put_u64(v)
+        OctetsMutRev::put_u64(self, v)
     }
 
     #[inline]
     fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]> {
-        self.put_varint_with_len(v, len)
+        OctetsMutRev::put_varint_with_len(self, v, len)
     }
 
     #[inline]
     fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
-        self.put_bytes(v)
+        OctetsMutRev::put_bytes(self, v)
     }
 
     #[inline]
     fn skip(&mut self, skip: usize) -> Result<()> {
-        self.skip(skip)
+        OctetsMutRev::skip(self, skip)
     }
 
     #[inline]
     fn rewind(&mut self, rewind: usize) -> Result<()> {
-        self.rewind(rewind)
+        OctetsMutRev::rewind(self, rewind)
     }
 
     #[inline]
     fn cap(&self) -> usize {
-        self.cap()
+        OctetsMutRev::cap(self)
     }
 
     #[inline]
     fn len(&self) -> usize {
-        self.len()
+        OctetsMutRev::len(self)
     }
 
     #[inline]
     fn is_empty(&self) -> bool {
-        self.is_empty()
+        OctetsMutRev::is_empty(self)
     }
 
     #[inline]
     fn off(&self) -> usize {
-        self.off()
+        OctetsMutRev::off(self)
     }
 
     #[inline]
     fn buf(&self) -> &[u8] {
-        self.buf()
+        OctetsMutRev::buf(self)
     }
 
     #[inline]
     fn to_vec(&self) -> Vec<u8> {
-        self.to_vec()
+        OctetsMutRev::to_vec(self)
     }
 }
 
@@ -2262,5 +2328,169 @@ mod tests {
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         ];
         assert_eq!(&d, &exp);
+    }
+
+    #[test]
+    fn get_u_rev() {
+        let d = [
+            11, 12, 13, 14, 15, 16, 17, 18, 7, 8, 9, 10, 4, 5, 6, 2, 3, 1,
+        ];
+        let mut b = OctetsRev::with_slice(&d);
+        assert_eq!(b.cap(), 18);
+        assert_eq!(b.off(), 18);
+        assert_eq!(b.get_u8().unwrap(), 1);
+        assert_eq!(b.cap(), 17);
+        assert_eq!(b.off(), 17);
+        assert_eq!(b.get_u16().unwrap(), 0x0203);
+        assert_eq!(b.cap(), 15);
+        assert_eq!(b.off(), 15);
+        assert_eq!(b.get_u24().unwrap(), 0x040506);
+        assert_eq!(b.cap(), 12);
+        assert_eq!(b.off(), 12);
+        assert_eq!(b.get_u32().unwrap(), 0x0708090a);
+        assert_eq!(b.cap(), 8);
+        assert_eq!(b.off(), 8);
+        assert_eq!(b.get_u64().unwrap(), 0x0b0c0d0e0f101112);
+        assert_eq!(b.cap(), 0);
+        assert_eq!(b.off(), 0);
+        assert!(b.get_u8().is_err());
+    }
+
+    #[test]
+    fn put_u_rev() {
+        let mut d = [0; 18];
+        {
+            let mut b = OctetsMutRev::with_slice(&mut d);
+            assert_eq!(b.cap(), 18);
+            assert_eq!(b.off(), 18);
+            assert!(b.put_u8(1).is_ok());
+            assert_eq!(b.cap(), 17);
+            assert_eq!(b.off(), 17);
+            assert!(b.put_u16(0x0203).is_ok());
+            assert_eq!(b.cap(), 15);
+            assert_eq!(b.off(), 15);
+            assert!(b.put_u24(0x040506).is_ok());
+            assert_eq!(b.cap(), 12);
+            assert_eq!(b.off(), 12);
+            assert!(b.put_u32(0x0708090a).is_ok());
+            assert_eq!(b.cap(), 8);
+            assert_eq!(b.off(), 8);
+            assert!(b.put_u64(0x0b0c0d0e0f101112).is_ok());
+            assert_eq!(b.cap(), 0);
+            assert_eq!(b.off(), 0);
+            assert!(b.put_u8(1).is_err());
+        }
+        let exp = [
+            11, 12, 13, 14, 15, 16, 17, 18, 7, 8, 9, 10, 4, 5, 6, 2, 3, 1,
+        ];
+        assert_eq!(&d, &exp);
+    }
+
+    #[test]
+    fn mixed_forward_backward() {
+        let mut d = [0; 10];
+        {
+            // Write 0xAA at the beginning and 0xBB at the end
+            let mut f = OctetsMut::with_slice(&mut d);
+            f.put_u8(0xAA).unwrap();
+
+            // Convert forward to backward, maintaining the same underlying buffer and offset.
+            let mut b = OctetsMutRev::from(f);
+            b.put_u8(0xBB).unwrap();
+        }
+        // Conversion maintains offset, so f.off=1 -> b.off=1, b.put_u8 -> b.off=0, writes d[0]
+        assert_eq!(d[0], 0xBB);
+
+        let mut d = [0; 10];
+        {
+            // d[0] = 0xAA, f.off = 1
+            let mut f = OctetsMut::with_slice(&mut d);
+            f.put_u8(0xAA).unwrap();
+
+            // d[9] = 0xBB, b.off = 9
+            let mut b = OctetsMutRev::with_slice(&mut d);
+            b.put_u8(0xBB).unwrap();
+        }
+        assert_eq!(d[0], 0xAA);
+        assert_eq!(d[9], 0xBB);
+    }
+
+    #[test]
+    fn conversion_test() {
+        let data = [1, 2, 3, 4, 5];
+        let mut f = Octets::with_slice(&data);
+        f.skip(2).unwrap();
+        assert_eq!(f.off(), 2);
+
+        let mut r = OctetsRev::from(f);
+        assert_eq!(r.off(), 2);
+        assert_eq!(r.get_u8().unwrap(), 2);
+        assert_eq!(r.get_u8().unwrap(), 1);
+
+        let mut f2 = Octets::from(r);
+        assert_eq!(f2.off(), 0);
+        assert_eq!(f2.get_u8().unwrap(), 1);
+    }
+
+    #[test]
+    fn slice_last() {
+        let d = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let mut b = Octets::with_slice(&d);
+        b.skip(5).unwrap();
+        assert_eq!(b.slice_last(2).unwrap(), [9, 10]);
+        assert_eq!(b.slice_last(5).unwrap(), [6, 7, 8, 9, 10]);
+        assert!(b.slice_last(6).is_err());
+    }
+
+    #[test]
+    fn slice_last_mut() {
+        let mut d = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        {
+            let mut b = OctetsMut::with_slice(&mut d);
+            b.skip(5).unwrap();
+            assert_eq!(b.slice_last(2).unwrap(), [9, 10]);
+        }
+        {
+            let mut b = OctetsMut::with_slice(&mut d);
+            b.skip(5).unwrap();
+            assert_eq!(b.slice_last(5).unwrap(), [6, 7, 8, 9, 10]);
+        }
+        {
+            let mut b = OctetsMut::with_slice(&mut d);
+            b.skip(5).unwrap();
+            assert!(b.slice_last(6).is_err());
+        }
+    }
+
+    #[test]
+    fn slice_last_rev() {
+        let d = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let mut b = OctetsRev::with_slice(&d);
+        // off points to 10, skip moves it to 5
+        b.skip(5).unwrap();
+        // slice_last for Rev should be relative to the beginning
+        assert_eq!(b.slice_last(2).unwrap(), [1, 2]);
+        assert_eq!(b.slice_last(5).unwrap(), [1, 2, 3, 4, 5]);
+        assert!(b.slice_last(6).is_err());
+    }
+
+    #[test]
+    fn slice_last_mut_rev() {
+        let mut d = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        {
+            let mut b = OctetsMutRev::with_slice(&mut d);
+            b.skip(5).unwrap();
+            assert_eq!(b.slice_last(2).unwrap(), [1, 2]);
+        }
+        {
+            let mut b = OctetsMutRev::with_slice(&mut d);
+            b.skip(5).unwrap();
+            assert_eq!(b.slice_last(5).unwrap(), [1, 2, 3, 4, 5]);
+        }
+        {
+            let mut b = OctetsMutRev::with_slice(&mut d);
+            b.skip(5).unwrap();
+            assert!(b.slice_last(6).is_err());
+        }
     }
 }

--- a/octets_rev/src/lib.rs
+++ b/octets_rev/src/lib.rs
@@ -24,24 +24,137 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+//! Zero-copy abstraction for parsing and constructing network packets.
+//!
+//! This crate provides a set of types for safely and efficiently reading from
+//! and writing to byte buffers. It is designed to be used in performance-critical
+//! applications like network protocol implementations, where minimizing copies
+//! is essential.
+//!
+//! It supports both classical left-to-right (forward) processing and right-to-left
+//! (backward) processing.
+//!
+//! # Examples
+//!
+//! Reading from a buffer:
+//! ```
+//! use octets_rev::Octets;
+//!
+//! let data = [0x01, 0x00, 0x42, 0x05, b'h', b'e', b'l', b'l', b'o'];
+//! let mut b = Octets::with_slice(&data);
+//!
+//! assert_eq!(b.get_u8(), Ok(1));
+//! assert_eq!(b.get_u16(), Ok(0x0042));
+//!
+//! let mut sub = b.get_bytes_with_u8_length().unwrap();
+//! assert_eq!(sub.as_ref(), b"hello");
+//! ```
+//!
+//! # Forward and Backward Processing
+//!
+//! This crate supports both forward and backward processing of buffers.
+//! `Octets` and `OctetsMut` operate from the beginning of the buffer towards the end.
+//! `OctetsRev` and `OctetsMutRev` operate from the end of the buffer towards the beginning.
+//!
+//! This is particularly useful for protocols that define fields relative to the end of a packet
+//! or when building a packet from both ends to avoid moving data.
+//!
+//! ```
+//! use octets_rev::{OctetsMut, OctetsMutRev, Octets, OctetsRev};
+//!
+//! let mut data = [0; 10];
+//!
+//! // Write 0x01 at the beginning
+//! {
+//!     let mut b = OctetsMut::with_slice(&mut data);
+//!     b.put_u8(0x01).unwrap();
+//! }
+//!
+//! // Write 0xFE at the end
+//! {
+//!     let mut b = OctetsMutRev::with_slice(&mut data);
+//!     b.put_u8(0xFE).unwrap();
+//! }
+//!
+//! assert_eq!(data[0], 0x01);
+//! assert_eq!(data[9], 0xFE);
+//!
+//! // Read them back
+//! let mut forward = Octets::with_slice(&data);
+//! assert_eq!(forward.get_u8(), Ok(0x01));
+//!
+//! let mut backward = OctetsRev::with_slice(&data);
+//! assert_eq!(backward.get_u8(), Ok(0xFE));
+//! ```
+//!
+//! # Generic Processing with Traits
+//!
+//! By using the [`OctetsRead`] and [`OctetsWrite`] traits, you can write
+//! generic code that works identically for both forward and backward buffers.
+//! This is possible because `OctetsRev` and `OctetsMutRev` ensure that "reading
+//! the next integer" always moves the cursor in the "natural" direction for
+//! that buffer.
+//!
+//! If a protocol defines a sequence of fields (e.g., [Type, ID]), the same
+//! generic function can parse these fields whether they are stored at the
+//! beginning of the packet (processed forward) or at the end of the packet
+//! (processed backward).
+//!
+//! ```
+//! use octets_rev::{OctetsRead, Octets, OctetsRev, Result};
+//!
+//! struct Frame {
+//!     ty: u8,
+//!     id: u16,
+//! }
+//!
+//! impl Frame {
+//!     /// This code is oblivious to whether R is forward or backward.
+//!     /// It just reads the "next" fields in the defined logical order.
+//!     fn parse<R: OctetsRead>(r: &mut R) -> Result<Self> {
+//!         let ty = r.get_u8()?;
+//!         let id = r.get_u16()?;
+//!         Ok(Frame { ty, id })
+//!     }
+//! }
+//!
+//! // Forward processing: Type=1, ID=0x0042.
+//! // Data is physically [0x01, 0x00, 0x42].
+//! {
+//!     let data = [0x01, 0x00, 0x42];
+//!     let mut forward = Octets::with_slice(&data);
+//!     let f_frame = Frame::parse(&mut forward).unwrap();
+//!     assert_eq!(f_frame.ty, 0x01);
+//!     assert_eq!(f_frame.id, 0x0042);
+//! }
+//!
+//! // Backward processing: Type=1, ID=0x0042.
+//! // Data is physically [0x00, 0x42, 0x01] because OctetsRev reads from the end.
+//! {
+//!     let data = [0x00, 0x42, 0x01];
+//!     let mut backward = OctetsRev::with_slice(&data);
+//!     let b_frame = Frame::parse(&mut backward).unwrap();
+//!     assert_eq!(b_frame.ty, 0x01);
+//!     assert_eq!(b_frame.id, 0x0042);
+//! }
+//! ```
+
 use branches::unlikely;
 /// Zero-copy abstraction for parsing and constructing network packets.
 use std::mem;
 use std::ops::Deref;
 use std::ptr;
 
-/// A specialized [`Result`] type for [`OctetsMut`] operations.
-///
-/// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
-/// [`OctetsMut`]: struct.OctetsMut.html
+/// A specialized [`Result`] type for buffer operations.
 pub type Result<T> = std::result::Result<T, BufferError>;
 
-/// An error indicating that the provided [`OctetsMut`] is not big enough.
-///
-/// [`OctetsMut`]: struct.OctetsMut.html
+/// An error indicating that a buffer operation failed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BufferError {
+    /// The provided buffer is not big enough to complete the operation.
     BufferTooShortError,
+
+    /// The buffer contains invalid data according to the protocol rules.
     BufferProtocolError,
 }
 
@@ -699,7 +812,7 @@ impl<'a> AsMut<[u8]> for OctetsMut<'a> {
 }
 
 /// Returns how many bytes it would take to encode `v` as a variable-length
-/// integer.
+/// integer in network byte-order.
 pub const fn varint_len(v: u64) -> usize {
     if v <= 63 {
         1
@@ -725,7 +838,8 @@ pub const fn varint_parse_len(first: u8) -> usize {
     }
 }
 
-/// The length is encoded within the last two bits of the last byte.
+/// Returns how long the variable-length integer is, given its last byte,
+/// when reading in reverse.
 pub const fn varint_parse_len_reverse(last: u8) -> usize {
     match last & !0xfc {
         0 => 1,
@@ -736,49 +850,135 @@ pub const fn varint_parse_len_reverse(last: u8) -> usize {
     }
 }
 
+/// A trait for reading from a byte buffer.
 pub trait OctetsRead {
+    /// The type of bytes returned by `get_bytes` and related functions.
     type Bytes: AsRef<[u8]>;
 
+    /// Reads an unsigned 8-bit integer and advances the buffer.
     fn get_u8(&mut self) -> Result<u8>;
+
+    /// Reads an unsigned 16-bit integer in network byte-order and advances the buffer.
     fn get_u16(&mut self) -> Result<u16>;
+
+    /// Reads an unsigned 24-bit integer in network byte-order and advances the buffer.
     fn get_u24(&mut self) -> Result<u32>;
+
+    /// Reads an unsigned 32-bit integer in network byte-order and advances the buffer.
     fn get_u32(&mut self) -> Result<u32>;
+
+    /// Reads an unsigned 64-bit integer in network byte-order and advances the buffer.
     fn get_u64(&mut self) -> Result<u64>;
+
+    /// Reads an unsigned variable-length integer in network byte-order and advances the buffer.
     fn get_varint(&mut self) -> Result<u64>;
+
+    /// Reads `len` bytes without copying and advances the buffer.
     fn get_bytes(&mut self, len: usize) -> Result<Self::Bytes>;
+
+    /// Reads `len` + 1 bytes without copying and advances the buffer, where `len` is an
+    /// unsigned 8-bit integer prefix.
     fn get_bytes_with_u8_length(&mut self) -> Result<Self::Bytes>;
+
+    /// Reads `len` + 2 bytes without copying and advances the buffer, where `len` is an
+    /// unsigned 16-bit integer prefix in network byte-order.
     fn get_bytes_with_u16_length(&mut self) -> Result<Self::Bytes>;
+
+    /// Reads `len` + varint bytes without copying and advances the buffer, where `len` is an
+    /// unsigned variable-length integer prefix in network byte-order.
     fn get_bytes_with_varint_length(&mut self) -> Result<Self::Bytes>;
+
+    /// Reads an unsigned 8-bit integer without advancing the buffer.
     fn peek_u8(&mut self) -> Result<u8>;
+
+    /// Reads `len` bytes without copying and without advancing the buffer.
     fn peek_bytes(&mut self, len: usize) -> Result<Self::Bytes>;
+
+    /// Advances the buffer's offset.
     fn skip(&mut self, skip: usize) -> Result<()>;
+
+    /// Rewinds the buffer's offset.
     fn rewind(&mut self, rewind: usize) -> Result<()>;
+
+    /// Returns the remaining capacity in the buffer.
     fn cap(&self) -> usize;
+
+    /// Returns the total length of the buffer.
     fn len(&self) -> usize;
+
+    /// Returns `true` if the buffer is empty.
     fn is_empty(&self) -> bool;
+
+    /// Returns the current offset of the buffer.
     fn off(&self) -> usize;
+
+    /// Returns a reference to the internal buffer.
     fn buf(&self) -> &[u8];
-    fn to_vec(&self) -> Vec<u8>;
-}
-pub trait OctetsWrite {
-    fn put_varint(&mut self, v: u64) -> Result<&mut [u8]>;
-    fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]>;
-    fn put_u8(&mut self, v: u8) -> Result<&mut [u8]>;
-    fn put_u16(&mut self, v: u16) -> Result<&mut [u8]>;
-    fn put_u24(&mut self, v: u32) -> Result<&mut [u8]>;
-    fn put_u32(&mut self, v: u32) -> Result<&mut [u8]>;
-    fn put_u64(&mut self, v: u64) -> Result<&mut [u8]>;
-    fn put_bytes(&mut self, v: &[u8]) -> Result<()>;
-    fn skip(&mut self, skip: usize) -> Result<()>;
-    fn rewind(&mut self, rewind: usize) -> Result<()>;
-    fn cap(&self) -> usize;
-    fn len(&self) -> usize;
-    fn is_empty(&self) -> bool;
-    fn off(&self) -> usize;
-    fn buf(&self) -> &[u8];
+
+    /// Copies the buffer from the current offset into a new `Vec<u8>`.
     fn to_vec(&self) -> Vec<u8>;
 }
 
+/// A trait for writing to a byte buffer.
+pub trait OctetsWrite {
+    /// Writes an unsigned variable-length integer in network byte-order and advances the buffer.
+    fn put_varint(&mut self, v: u64) -> Result<&mut [u8]>;
+
+    /// Writes an unsigned variable-length integer of the specified length in network byte-order
+    /// and advances the buffer.
+    fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]>;
+
+    /// Writes an unsigned 8-bit integer and advances the buffer.
+    fn put_u8(&mut self, v: u8) -> Result<&mut [u8]>;
+
+    /// Writes an unsigned 16-bit integer in network byte-order and advances the buffer.
+    fn put_u16(&mut self, v: u16) -> Result<&mut [u8]>;
+
+    /// Writes an unsigned 24-bit integer in network byte-order and advances the buffer.
+    fn put_u24(&mut self, v: u32) -> Result<&mut [u8]>;
+
+    /// Writes an unsigned 32-bit integer in network byte-order and advances the buffer.
+    fn put_u32(&mut self, v: u32) -> Result<&mut [u8]>;
+
+    /// Writes an unsigned 64-bit integer in network byte-order and advances the buffer.
+    fn put_u64(&mut self, v: u64) -> Result<&mut [u8]>;
+
+    /// Writes `v.len()` bytes by copying and advances the buffer.
+    fn put_bytes(&mut self, v: &[u8]) -> Result<()>;
+
+    /// Advances the buffer's offset.
+    fn skip(&mut self, skip: usize) -> Result<()>;
+
+    /// Rewinds the buffer's offset.
+    fn rewind(&mut self, rewind: usize) -> Result<()>;
+
+    /// Returns the remaining capacity in the buffer.
+    fn cap(&self) -> usize;
+
+    /// Returns the total length of the buffer.
+    fn len(&self) -> usize;
+
+    /// Returns `true` if the buffer is empty.
+    fn is_empty(&self) -> bool;
+
+    /// Returns the current offset of the buffer.
+    fn off(&self) -> usize;
+
+    /// Returns a reference to the internal buffer.
+    fn buf(&self) -> &[u8];
+
+    /// Copies the buffer from the current offset into a new `Vec<u8>`.
+    fn to_vec(&self) -> Vec<u8>;
+}
+
+/// A zero-copy immutable byte buffer for backward processing.
+///
+/// `OctetsRev` is similar to `Octets`, but it operates from the end of the buffer
+/// towards the beginning. The cursor (offset) initially points to the end of the
+/// buffer and moves backwards as data is read.
+///
+/// For each `get_u*` or `get_varint` operation, the offset is first decreased
+/// by the size of the integer, and then the value is read from that new offset.
 #[derive(Debug, PartialEq, Eq)]
 pub struct OctetsRev<'a> {
     buf: &'a [u8],
@@ -786,8 +986,8 @@ pub struct OctetsRev<'a> {
 }
 
 impl<'a> OctetsRev<'a> {
-    /// Instantiate an OctetsRev pointing the cursor at the rightmost
-    /// offset of the slice.
+    /// Creates an `OctetsRev` from the given slice, pointing the cursor at the
+    /// end of the slice.
     pub fn with_slice(buf: &'a [u8]) -> Self {
         OctetsRev {
             buf,
@@ -795,7 +995,8 @@ impl<'a> OctetsRev<'a> {
         }
     }
 
-    /// Decreases the buffer's offset by 1 and reads an unsigned 8-bit integer
+    /// Reads an unsigned 8-bit integer by first decreasing the offset by 1
+    /// and then reading at that offset.
     pub fn get_u8(&mut self) -> Result<u8> {
         get_u_reverse!(self, u8, 1);
     }
@@ -806,31 +1007,37 @@ impl<'a> OctetsRev<'a> {
         peek_u_reverse!(self, u8, 1)
     }
 
-    /// Decreases the buffer's offset by 2 and then reads an unsigned 16-bit integer
+    /// Reads an unsigned 16-bit integer in network byte-order by first
+    /// decreasing the offset by 2 and then reading at that offset.
     pub fn get_u16(&mut self) -> Result<u16> {
         get_u_reverse!(self, u16, 2)
     }
 
-    /// Decreases the buffer's offset by 3 and then reads 24 bits into an unsigned 32-bit integer
+    /// Reads an unsigned 24-bit integer in network byte-order by first
+    /// decreasing the offset by 3 and then reading at that offset.
     pub fn get_u24(&mut self) -> Result<u32> {
         get_u_reverse!(self, u32, 3)
     }
 
-    /// Decreases the buffer's offset by 4 and then reads an unsigned 32-bit integer
+    /// Reads an unsigned 32-bit integer in network byte-order by first
+    /// decreasing the offset by 4 and then reading at that offset.
     pub fn get_u32(&mut self) -> Result<u32> {
         get_u_reverse!(self, u32, 4)
     }
 
-    /// Decreases the buffer's offset by 8 and then reads an unsigned 64-bit integer
+    /// Reads an unsigned 64-bit integer in network byte-order by first
+    /// decreasing the offset by 8 and then reading at that offset.
     pub fn get_u64(&mut self) -> Result<u64> {
         get_u_reverse!(self, u64, 8)
     }
 
-    /// In reversed buffers, variable length integers also need to be
-    /// reversed, with the 2-bits length indicator at the end of the first
-    /// byte in the backward direction.
-    /// Reads an unsigned variable-length integer in network byte-order from
-    /// the current offset and rewinds the buffer.
+    /// Reads an unsigned variable-length integer in network byte-order by
+    /// first decreasing the offset by the integer's length and then reading
+    /// at that offset.
+    ///
+    /// In reversed buffers, variable-length integers have their length indicator
+    /// bits (the 2 most significant bits) in the "first" byte in the backward
+    /// direction (which is the last byte in forward direction).
     pub fn get_varint(&mut self) -> Result<u64> {
         if unlikely(self.off == 0) {
             Err(BufferError::BufferProtocolError)
@@ -848,8 +1055,9 @@ impl<'a> OctetsRev<'a> {
         }
     }
 
-    /// Rewind the buffer of  `len` bytes from the current offset and then
-    /// read without copying.
+    /// Reads `len` bytes from the current offset (moving backwards) without
+    /// copying. The offset is decreased by `len`. The returned `Octets`
+    /// is forward-oriented.
     pub fn get_bytes(&mut self, len: usize) -> Result<Octets<'a>> {
         if unlikely(self.off < len) {
             Err(BufferError::BufferProtocolError)
@@ -863,28 +1071,28 @@ impl<'a> OctetsRev<'a> {
         }
     }
 
-    /// Rewind the buffer of `len` bytes and read `len` bytes  without copying.
+    /// Reads `len` + 1 bytes from the current offset (moving backwards) without
+    /// copying, where `len` is an unsigned 8-bit integer prefix.
     pub fn get_bytes_with_u8_length(&mut self) -> Result<Octets<'a>> {
         let len = self.get_u8()?;
         self.get_bytes(len as usize)
     }
 
-    /// Rewind the buffer of `len`+ 2 bytes and read `len` bytes  without
-    /// copying.
+    /// Reads `len` + 2 bytes from the current offset (moving backwards) without
+    /// copying, where `len` is an unsigned 16-bit integer prefix.
     pub fn get_bytes_with_u16_length(&mut self) -> Result<Octets<'a>> {
         let len = self.get_u16()?;
         self.get_bytes(len as usize)
     }
 
-    /// Rewind the buffer of `len`+ varint bytes and read `len` bytes without
-    /// copying.
+    /// Reads `len` + varint bytes from the current offset (moving backwards)
+    /// without copying, where `len` is an unsigned variable-length integer prefix.
     pub fn get_bytes_with_varint_length(&mut self) -> Result<Octets<'a>> {
         let len = self.get_varint()?;
         self.get_bytes(len as usize)
     }
 
-    /// Advances the buffer's offset, moving the offset towars
-    /// lower values.
+    /// Advances the buffer's offset, moving it towards the beginning (lower values).
     pub fn skip(&mut self, skip: usize) -> Result<()> {
         if self.off < skip {
             return Err(BufferError::BufferTooShortError);
@@ -893,8 +1101,7 @@ impl<'a> OctetsRev<'a> {
         Ok(())
     }
 
-    /// Rewinds the buffer's offset, moving the offset towards
-    /// higher values.
+    /// Rewinds the buffer's offset, moving it towards the end (higher values).
     pub fn rewind(&mut self, rewind: usize) -> Result<()> {
         if rewind > self.buf.len() - self.off {
             return Err(BufferError::BufferTooShortError);
@@ -903,6 +1110,7 @@ impl<'a> OctetsRev<'a> {
         Ok(())
     }
 
+    /// Returns the remaining capacity in the buffer (bytes before the cursor).
     pub fn cap(&self) -> usize {
         self.off
     }
@@ -967,6 +1175,13 @@ impl<'a> From<OctetsRev<'a>> for Octets<'a> {
     }
 }
 
+/// A zero-copy mutable byte buffer for backward processing.
+///
+/// `OctetsMutRev` is the mutable version of `OctetsRev`. It operates from the
+/// end of the buffer towards the beginning.
+///
+/// For each `put_u*` or `put_varint` operation, the offset is first decreased
+/// by the size of the integer, and then the value is written at that new offset.
 #[derive(Debug, PartialEq, Eq)]
 pub struct OctetsMutRev<'a> {
     buf: &'a mut [u8],
@@ -974,43 +1189,54 @@ pub struct OctetsMutRev<'a> {
 }
 
 impl<'a> OctetsMutRev<'a> {
+    /// Creates an `OctetsMutRev` from the given slice, pointing the cursor at
+    /// the end of the slice.
     pub fn with_slice(buf: &'a mut [u8]) -> Self {
         let len = buf.len();
         OctetsMutRev { buf, off: len }
     }
 
-    pub fn from_octetsmut(o: OctetsMut<'a>) -> Self {
-        let off = o.off();
-        OctetsMutRev { buf: o.buf, off }
-    }
-
-    /// Advance the buffer by 1 bytes (decreasing its offset) and
-    /// then write 1 byte at the current offset.
+    /// Writes an unsigned 8-bit integer by first decreasing the offset by 1
+    /// and then writing at that offset.
     pub fn put_u8(&mut self, v: u8) -> Result<&mut [u8]> {
         put_u_reverse!(self, u8, v, 1)
     }
 
+    /// Writes an unsigned 16-bit integer in network byte-order by first
+    /// decreasing the offset by 2 and then writing at that offset.
     pub fn put_u16(&mut self, v: u16) -> Result<&mut [u8]> {
         put_u_reverse!(self, u16, v, 2)
     }
 
+    /// Writes an unsigned 24-bit integer in network byte-order by first
+    /// decreasing the offset by 3 and then writing at that offset.
     pub fn put_u24(&mut self, v: u32) -> Result<&mut [u8]> {
         put_u_reverse!(self, u32, v, 3)
     }
 
+    /// Writes an unsigned 32-bit integer in network byte-order by first
+    /// decreasing the offset by 4 and then writing at that offset.
     pub fn put_u32(&mut self, v: u32) -> Result<&mut [u8]> {
         put_u_reverse!(self, u32, v, 4)
     }
 
+    /// Writes an unsigned 64-bit integer in network byte-order by first
+    /// decreasing the offset by 8 and then writing at that offset.
     pub fn put_u64(&mut self, v: u64) -> Result<&mut [u8]> {
         put_u_reverse!(self, u64, v, 8)
     }
 
+    /// Writes an unsigned variable-length integer in network byte-order by
+    /// first decreasing the offset by the integer's length and then writing
+    /// at that offset.
     #[inline]
     pub fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
         self.put_varint_with_len(v, varint_len(v))
     }
 
+    /// Writes an unsigned variable-length integer of the specified length in
+    /// network byte-order by first decreasing the offset by `len` and then
+    /// writing at that offset.
     #[inline]
     pub fn put_varint_with_len(
         &mut self, v: u64, len: usize,
@@ -1040,8 +1266,8 @@ impl<'a> OctetsMutRev<'a> {
         Ok(buf)
     }
 
-    /// Advance the buffer by decreasing the offset of `len` and then Writes `len` bytes
-    /// by copy at the decreased offset value.
+    /// Writes `v.len()` bytes by copying them at the current offset (moving
+    /// backwards). The offset is decreased by `v.len()`.
     pub fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
         let len = v.len();
         if self.cap() < len {
@@ -1055,7 +1281,7 @@ impl<'a> OctetsMutRev<'a> {
         Ok(())
     }
 
-    /// Advances the buffer, moving the offet towards lower values.
+    /// Advances the buffer's offset, moving it towards the beginning (lower values).
     pub fn skip(&mut self, skip: usize) -> Result<()> {
         if self.off < skip {
             return Err(BufferError::BufferTooShortError);
@@ -1064,7 +1290,7 @@ impl<'a> OctetsMutRev<'a> {
         Ok(())
     }
 
-    /// Rewinds the buffer, moving the offet towards higher values.
+    /// Rewinds the buffer's offset, moving it towards the end (higher values).
     pub fn rewind(&mut self, rewind: usize) -> Result<()> {
         if rewind > self.buf.len() - self.off {
             return Err(BufferError::BufferTooShortError);
@@ -1073,6 +1299,7 @@ impl<'a> OctetsMutRev<'a> {
         Ok(())
     }
 
+    /// Returns the remaining capacity in the buffer (bytes before the cursor).
     pub fn cap(&self) -> usize {
         self.off
     }

--- a/octets_rev/src/lib.rs
+++ b/octets_rev/src/lib.rs
@@ -39,7 +39,6 @@ pub type Result<T> = std::result::Result<T, BufferError>;
 /// An error indicating that the provided [`OctetsMut`] is not big enough.
 ///
 /// [`OctetsMut`]: struct.OctetsMut.html
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BufferError {
     BufferTooShortError,
@@ -65,37 +64,29 @@ macro_rules! peek_u {
     ($b:expr, $ty:ty, $len:expr) => {{
         let len = $len;
         let src = &$b.buf[$b.off..];
-
         if src.len() < len {
             return Err(BufferError::BufferTooShortError);
         }
-
         let mut out: $ty = 0;
         unsafe {
             let dst = &mut out as *mut $ty as *mut u8;
             let off = (mem::size_of::<$ty>() - len) as isize;
-
             ptr::copy_nonoverlapping(src.as_ptr(), dst.offset(off), len);
         };
-
         Ok(<$ty>::from_be(out))
     }};
 }
 
 macro_rules! peek_u_buflen_guaranteed {
-    ($b:expr, $ty:ty, $len:expr) => {{
+    ($b:expr, $ty:ty , $len:expr) => {{
         let len = $len;
         let src = &$b.buf[$b.off..];
-
         let mut out: $ty = 0;
-        // XXX Todo - fix this with a byte-by-byte copy instead
         unsafe {
             let dst = &mut out as *mut $ty as *mut u8;
             let off = (mem::size_of::<$ty>() - len) as isize;
-
             ptr::copy_nonoverlapping(src.as_ptr(), dst.offset(off), len);
         };
-
         Ok(<$ty>::from_be(out))
     }};
 }
@@ -103,17 +94,15 @@ macro_rules! peek_u_buflen_guaranteed {
 macro_rules! get_u {
     ($b:expr, $ty:ty, $len:expr) => {{
         let out = peek_u!($b, $ty, $len);
-
         $b.off += $len;
-
         out
     }};
 }
 
 macro_rules! peek_u_reverse {
-    ($b:expr, $ty:ty, $len:expr) => {{
+    ($b:expr, $ty:ty , $len:expr) => {{
         if_unlikely! { $b.off < $len => {
-            return Err(BufferError::BufferProtocolError);
+            return Err (BufferError::BufferProtocolError);
         } else {
             $b.off -= $len;
             let out = peek_u_buflen_guaranteed!($b, $ty, $len);
@@ -123,21 +112,17 @@ macro_rules! peek_u_reverse {
     }};
 }
 
-/// The set of [..]_reverse() functions uses this macro to read the buffer
+/// The set of [..]() functions uses this macro to read the buffer
 /// in the reverse direction, from the end to the beginning, like reading
 /// a Manga.
 ///
 /// For example, we start at offset = buf.len(); then rewind 1 byte to read 1
 /// byte. The buffer offset keeps moving backward while reading information with
-/// the set of [..]_reverse() functions.
+/// the set of [..]() functions.
 macro_rules! get_u_reverse {
     ($b:expr, $ty:ty, $len:expr) => {{
         if_unlikely! { $b.off < $len => {
-            // This is protocol-level bug -- Could happen if received frames
-            // are missing elements.
-            // Or if we're reading things we should not. In that case, it is
-            // a simple bug.
-            return Err(BufferError::BufferProtocolError);
+            return Err (BufferError::BufferProtocolError);
         } else {
             $b.off -= $len;
             let out = peek_u_buflen_guaranteed!($b, $ty, $len);
@@ -146,27 +131,38 @@ macro_rules! get_u_reverse {
     }};
 }
 
+macro_rules! put_u_reverse {
+    ($b:expr, $ty:ty, $v:expr, $len:expr) => {{
+        let len = $len;
+        if $b.off < len {
+            return Err(BufferError::BufferTooShortError);
+        }
+        $b.off -= len;
+        let v = $v;
+        let dst = &mut $b.buf[$b.off..($b.off + len)];
+        unsafe {
+            let src = &<$ty>::to_be(v) as *const $ty as *const u8;
+            let off = (std::mem::size_of::<$ty>() - len) as isize;
+            std::ptr::copy_nonoverlapping(src.offset(off), dst.as_mut_ptr(), len);
+        }
+        Ok(dst)
+    }};
+}
+
 macro_rules! put_u {
     ($b:expr, $ty:ty, $v:expr, $len:expr) => {{
         let len = $len;
-
         if $b.buf.len() < $b.off + len {
             return Err(BufferError::BufferTooShortError);
         }
-
         let v = $v;
-
         let dst = &mut $b.buf[$b.off..($b.off + len)];
-
         unsafe {
             let src = &<$ty>::to_be(v) as *const $ty as *const u8;
             let off = (mem::size_of::<$ty>() - len) as isize;
-
             ptr::copy_nonoverlapping(src.offset(off), dst.as_mut_ptr(), len);
         }
-
         $b.off += $len;
-
         Ok(dst)
     }};
 }
@@ -186,7 +182,6 @@ pub struct Octets<'a> {
     buf: &'a [u8],
     off: usize,
 }
-
 impl<'a> Octets<'a> {
     /// Creates an `Octets` from the given slice, without copying.
     ///
@@ -202,19 +197,10 @@ impl<'a> Octets<'a> {
         get_u!(self, u8, 1)
     }
 
-    /// Decreases the buffer's offset by 1 and reads an unsigned 8-bit integer
-    pub fn get_u8_reverse(&mut self) -> Result<u8> {
-        get_u_reverse!(self, u8, 1);
-    }
-
     /// Reads an unsigned 8-bit integer from the current offset without
     /// advancing the buffer.
     pub fn peek_u8(&mut self) -> Result<u8> {
         peek_u!(self, u8, 1)
-    }
-
-    pub fn peek_u8_reverse(&mut self) -> Result<u8> {
-        peek_u_reverse!(self, u8, 1)
     }
 
     /// Reads an unsigned 16-bit integer in network byte-order from the current
@@ -223,19 +209,10 @@ impl<'a> Octets<'a> {
         get_u!(self, u16, 2)
     }
 
-    /// Decreases the buffer's offset by 2 and reads an unsigned 16-bit integer
-    pub fn get_u16_reverse(&mut self) -> Result<u16> {
-        get_u_reverse!(self, u16, 2)
-    }
-
     /// Reads an unsigned 24-bit integer in network byte-order from the current
     /// offset and advances the buffer.
     pub fn get_u24(&mut self) -> Result<u32> {
         get_u!(self, u32, 3)
-    }
-
-    pub fn get_u24_reverse(&mut self) -> Result<u32> {
-        get_u_reverse!(self, u32, 3)
     }
 
     /// Reads an unsigned 32-bit integer in network byte-order from the current
@@ -244,73 +221,28 @@ impl<'a> Octets<'a> {
         get_u!(self, u32, 4)
     }
 
-    pub fn get_u32_reverse(&mut self) -> Result<u32> {
-        get_u_reverse!(self, u32, 4)
-    }
-
     /// Reads an unsigned 64-bit integer in network byte-order from the current
     /// offset and advances the buffer.
     pub fn get_u64(&mut self) -> Result<u64> {
         get_u!(self, u64, 8)
     }
 
-    pub fn get_u64_reverse(&mut self) -> Result<u64> {
-        get_u_reverse!(self, u64, 8)
-    }
-
     /// Reads an unsigned variable-length integer in network byte-order from
     /// the current offset and advances the buffer.
     pub fn get_varint(&mut self) -> Result<u64> {
         let first = self.peek_u8()?;
-
         let len = varint_parse_len(first);
-
         if len > self.cap() {
             return Err(BufferError::BufferTooShortError);
         }
-
         let out = match len {
             1 => u64::from(self.get_u8()? & 0x3f),
-
             2 => u64::from(self.get_u16()? & 0x3fff),
-
             4 => u64::from(self.get_u32()? & 0x3fffffff),
-
             8 => self.get_u64()? & 0x3fffffffffffffff,
-
             _ => unreachable!(),
         };
-
         Ok(out)
-    }
-
-    /// On PROTOCOL_VERSION_VREVERSO, variable length integers also need to be
-    /// "reversed", with the 2-bits length indicator at the end of the last
-    /// byte.
-    pub fn get_varint_reverse(&mut self) -> Result<u64> {
-        if_unlikely! { self.off == 0 => {
-            Err(BufferError::BufferProtocolError)
-        } else {
-            self.off -= 1;
-            // This checks buffer size while we don't need it.
-            let last = self.peek_u8()?;
-            let len = varint_parse_len_reverse(last);
-            // Parse the whole varint and remove the last two bits
-            self.off += 1;
-
-            let out = match len {
-                1 => u64::from(self.get_u8_reverse()? >> 2),
-
-                2 => u64::from(self.get_u16_reverse()? >> 2),
-
-                4 => u64::from(self.get_u32_reverse()? >> 2),
-
-                8 => self.get_u64_reverse()? >> 2,
-
-                _ => unreachable!(),
-            };
-            Ok(out)
-        }}
     }
 
     /// Reads `len` bytes from the current offset without copying and advances
@@ -319,31 +251,12 @@ impl<'a> Octets<'a> {
         if self.cap() < len {
             return Err(BufferError::BufferTooShortError);
         }
-
         let out = Octets {
             buf: &self.buf[self.off..self.off + len],
             off: 0,
         };
-
         self.off += len;
-
         Ok(out)
-    }
-
-    /// Rewind the buffer of  `len` bytes from the current offset and then
-    /// read without copying.
-    pub fn get_bytes_reverse(&mut self, len: usize) -> Result<Octets<'a>> {
-        if_unlikely! { self.off < len => {
-            Err(BufferError::BufferProtocolError)
-        } else {
-            self.off -= len;
-            let out = Octets {
-                buf: &self.buf[self.off..self.off + len],
-                off: 0,
-            };
-
-            Ok(out)
-        }}
     }
 
     /// Reads `len` + 1 bytes from the current offset without copying and
@@ -354,25 +267,12 @@ impl<'a> Octets<'a> {
         self.get_bytes(len as usize)
     }
 
-    /// Rewind the buffer of `len` bytes and read `len` bytes  without copying.
-    pub fn get_bytes_with_u8_length_reverse(&mut self) -> Result<Octets<'a>> {
-        let len = self.get_u8_reverse()?;
-        self.get_bytes_reverse(len as usize)
-    }
-
     /// Reads `len` bytes from the current offset without copying and advances
     /// the buffer, where `len` is an unsigned 16-bit integer prefix in network
     /// byte-order.
     pub fn get_bytes_with_u16_length(&mut self) -> Result<Octets<'a>> {
         let len = self.get_u16()?;
         self.get_bytes(len as usize)
-    }
-
-    /// Rewind the buffer of `len`+ 2 bytes and read `len` bytes  without
-    /// copying.
-    pub fn get_bytes_with_u16_length_reverse(&mut self) -> Result<Octets<'a>> {
-        let len = self.get_u16_reverse()?;
-        self.get_bytes_reverse(len as usize)
     }
 
     /// Reads `len` bytes from the current offset without copying and advances
@@ -383,25 +283,16 @@ impl<'a> Octets<'a> {
         self.get_bytes(len as usize)
     }
 
-    /// Rewind the buffer of `len`+ varint bytes and read `len` bytes without
-    /// copying.
-    pub fn get_bytes_with_varint_length_reverse(&mut self) -> Result<Octets<'a>> {
-        let len = self.get_varint_reverse()?;
-        self.get_bytes_reverse(len as usize)
-    }
-
     /// Reads `len` bytes from the current offset without copying and without
     /// advancing the buffer.
     pub fn peek_bytes(&self, len: usize) -> Result<Octets<'a>> {
         if self.cap() < len {
             return Err(BufferError::BufferTooShortError);
         }
-
         let out = Octets {
             buf: &self.buf[self.off..self.off + len],
             off: 0,
         };
-
         Ok(out)
     }
 
@@ -410,7 +301,6 @@ impl<'a> Octets<'a> {
         if len > self.cap() {
             return Err(BufferError::BufferTooShortError);
         }
-
         Ok(&self.buf[self.off..self.off + len])
     }
 
@@ -419,7 +309,6 @@ impl<'a> Octets<'a> {
         if len > self.cap() {
             return Err(BufferError::BufferTooShortError);
         }
-
         let cap = self.cap();
         Ok(&self.buf[cap - len..])
     }
@@ -429,32 +318,21 @@ impl<'a> Octets<'a> {
         if skip > self.cap() {
             return Err(BufferError::BufferTooShortError);
         }
-
         self.off += skip;
-
         Ok(())
     }
 
-    /// Rewind the buffer's offset.
     pub fn rewind(&mut self, rewind: usize) -> Result<()> {
-        if self.off < rewind {
+        if rewind > self.off {
             return Err(BufferError::BufferTooShortError);
         }
-
         self.off -= rewind;
-
         Ok(())
     }
 
     /// Returns the remaining capacity in the buffer.
     pub fn cap(&self) -> usize {
         self.buf.len() - self.off
-    }
-
-    /// Returns the remaining capacity in the buffer while reading
-    /// it on PROTOCOL_VERSION_VREVERSO.
-    pub fn cap_reverse(&self) -> usize {
-        self.off
     }
 
     /// Returns the total length of the buffer.
@@ -585,25 +463,17 @@ impl<'a> OctetsMut<'a> {
     /// the current offset and advances the buffer.
     pub fn get_varint(&mut self) -> Result<u64> {
         let first = self.peek_u8()?;
-
         let len = varint_parse_len(first);
-
         if len > self.cap() {
             return Err(BufferError::BufferTooShortError);
         }
-
         let out = match len {
             1 => u64::from(self.get_u8()?),
-
             2 => u64::from(self.get_u16()? & 0x3fff),
-
             4 => u64::from(self.get_u32()? & 0x3fffffff),
-
             8 => self.get_u64()? & 0x3fffffffffffffff,
-
             _ => unreachable!(),
         };
-
         Ok(out)
     }
 
@@ -621,70 +491,25 @@ impl<'a> OctetsMut<'a> {
         if self.cap() < len {
             return Err(BufferError::BufferTooShortError);
         }
-
         let buf = match len {
             1 => self.put_u8(v as u8)?,
-
             2 => {
                 let buf = self.put_u16(v as u16)?;
                 buf[0] |= 0x40;
                 buf
             },
-
             4 => {
                 let buf = self.put_u32(v as u32)?;
                 buf[0] |= 0x80;
                 buf
             },
-
             8 => {
                 let buf = self.put_u64(v)?;
                 buf[0] |= 0xc0;
                 buf
             },
-
             _ => panic!("value is too large for varint"),
         };
-
-        Ok(buf)
-    }
-
-    /// Variable-Length Integer where the length information are located
-    /// in the two least significant bits.
-    #[inline]
-    pub fn put_varint_reverse(&mut self, v: u64) -> Result<&mut [u8]> {
-        self.put_varint_with_len_reverse(v, varint_len(v))
-    }
-
-    #[inline]
-    pub fn put_varint_with_len_reverse(
-        &mut self, v: u64, len: usize,
-    ) -> Result<&mut [u8]> {
-        if self.cap() < len {
-            return Err(BufferError::BufferTooShortError);
-        }
-
-        let buf = match len {
-            1 => self.put_u8((v << 2) as u8)?,
-
-            2 => {
-                let buf = self.put_u16((v << 2) as u16)?;
-                buf[1] |= 0x1;
-                buf
-            },
-            4 => {
-                let buf = self.put_u32((v << 2) as u32)?;
-                buf[3] |= 0x2;
-                buf
-            },
-            8 => {
-                let buf = self.put_u64(v << 2)?;
-                buf[7] |= 0x3;
-                buf
-            },
-            _ => panic!("value is too large for varint"),
-        };
-
         Ok(buf)
     }
 
@@ -694,14 +519,11 @@ impl<'a> OctetsMut<'a> {
         if self.cap() < len {
             return Err(BufferError::BufferTooShortError);
         }
-
         let out = Octets {
             buf: &self.buf[self.off..self.off + len],
             off: 0,
         };
-
         self.off += len;
-
         Ok(out)
     }
 
@@ -711,14 +533,11 @@ impl<'a> OctetsMut<'a> {
         if self.cap() < len {
             return Err(BufferError::BufferTooShortError);
         }
-
         let out = OctetsMut {
             buf: &mut self.buf[self.off..self.off + len],
             off: 0,
         };
-
         self.off += len;
-
         Ok(out)
     }
 
@@ -736,7 +555,6 @@ impl<'a> OctetsMut<'a> {
         let len = self.get_u16()?;
         self.get_bytes(len as usize)
     }
-
     /// Reads `len` bytes from the current offset without copying and advances
     /// the buffer, where `len` is an unsigned variable-length integer prefix
     /// in network byte-order.
@@ -751,12 +569,10 @@ impl<'a> OctetsMut<'a> {
         if self.cap() < len {
             return Err(BufferError::BufferTooShortError);
         }
-
         let out = Octets {
             buf: &self.buf[self.off..self.off + len],
             off: 0,
         };
-
         Ok(out)
     }
 
@@ -766,12 +582,10 @@ impl<'a> OctetsMut<'a> {
         if self.cap() < len {
             return Err(BufferError::BufferTooShortError);
         }
-
         let out = OctetsMut {
             buf: &mut self.buf[self.off..self.off + len],
             off: 0,
         };
-
         Ok(out)
     }
 
@@ -779,19 +593,14 @@ impl<'a> OctetsMut<'a> {
     /// the buffer.
     pub fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
         let len = v.len();
-
         if self.cap() < len {
             return Err(BufferError::BufferTooShortError);
         }
-
         if len == 0 {
             return Ok(());
         }
-
         self.as_mut()[..len].copy_from_slice(v);
-
         self.off += len;
-
         Ok(())
     }
 
@@ -802,13 +611,9 @@ impl<'a> OctetsMut<'a> {
         if self.len() < off {
             return Err(BufferError::BufferTooShortError);
         }
-
         let (left, right) = self.buf.split_at_mut(off);
-
         let first = OctetsMut { buf: left, off: 0 };
-
         let last = OctetsMut { buf: right, off: 0 };
-
         Ok((first, last))
     }
 
@@ -817,7 +622,6 @@ impl<'a> OctetsMut<'a> {
         if len > self.cap() {
             return Err(BufferError::BufferTooShortError);
         }
-
         Ok(&mut self.buf[self.off..self.off + len])
     }
 
@@ -826,7 +630,6 @@ impl<'a> OctetsMut<'a> {
         if len > self.cap() {
             return Err(BufferError::BufferTooShortError);
         }
-
         let cap = self.cap();
         Ok(&mut self.buf[cap - len..])
     }
@@ -836,32 +639,22 @@ impl<'a> OctetsMut<'a> {
         if skip > self.cap() {
             return Err(BufferError::BufferTooShortError);
         }
-
         self.off += skip;
-
         Ok(())
     }
 
-    /// Rewind the buffer's offset.
+    /// Rewinds the buffer's offset.
     pub fn rewind(&mut self, rewind: usize) -> Result<()> {
         if self.off < rewind {
             return Err(BufferError::BufferTooShortError);
         }
-
         self.off -= rewind;
-
         Ok(())
     }
 
     /// Returns the remaining capacity in the buffer.
     pub fn cap(&self) -> usize {
         self.buf.len() - self.off
-    }
-
-    /// Returns the remaining capacity in the buffer for the reverse
-    /// frame processing.
-    pub fn cap_reverse(&self) -> usize {
-        self.off
     }
 
     /// Returns the total length of the buffer.
@@ -940,40 +733,677 @@ pub const fn varint_parse_len_reverse(last: u8) -> usize {
     }
 }
 
+pub trait OctetsRead<'a> {
+    type Bytes;
+
+    fn get_u8(&mut self) -> Result<u8>;
+    fn get_u16(&mut self) -> Result<u16>;
+    fn get_u24(&mut self) -> Result<u32>;
+    fn get_u32(&mut self) -> Result<u32>;
+    fn get_u64(&mut self) -> Result<u64>;
+    fn get_varint(&mut self) -> Result<u64>;
+    fn get_bytes(&mut self, len: usize) -> Result<Self::Bytes>;
+    fn get_bytes_with_u8_length(&mut self) -> Result<Self::Bytes>;
+    fn get_bytes_with_u16_length(&mut self) -> Result<Self::Bytes>;
+    fn get_bytes_with_varint_length(&mut self) -> Result<Self::Bytes>;
+    fn peek_u8(&mut self) -> Result<u8>;
+    fn skip(&mut self, skip: usize) -> Result<()>;
+    fn rewind(&mut self, rewind: usize) -> Result<()>;
+    fn cap(&self) -> usize;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool;
+    fn off(&self) -> usize;
+    fn buf(&self) -> &'a [u8];
+    fn to_vec(&self) -> Vec<u8>;
+}
+pub trait OctetsWrite<'a> {
+    fn put_varint(&mut self, v: u64) -> Result<&mut [u8]>;
+    fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]>;
+    fn skip(&mut self, skip: usize) -> Result<()>;
+    fn rewind(&mut self, rewind: usize) -> Result<()>;
+    fn cap(&self) -> usize;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool;
+    fn off(&self) -> usize;
+    fn buf(&self) -> &[u8];
+    fn to_vec(&self) -> Vec<u8>;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct OctetsRev<'a> {
+    buf: &'a [u8],
+    off: usize,
+}
+
+impl<'a> OctetsRev<'a> {
+    /// Instantiate an OctetsRev pointing the cursor at the rightmost
+    /// offset of the slice.
+    pub fn with_slice(buf: &'a [u8]) -> Self {
+        OctetsRev {
+            buf,
+            off: buf.len(),
+        }
+    }
+
+    /// Decreases the buffer's offset by 1 and reads an unsigned 8-bit integer
+    pub fn get_u8(&mut self) -> Result<u8> {
+        get_u_reverse!(self, u8, 1);
+    }
+
+    /// Reads an unsigned 8-bit integer from the current offset without
+    /// rewinding the buffer.
+    pub fn peek_u8(&mut self) -> Result<u8> {
+        peek_u_reverse!(self, u8, 1)
+    }
+
+    /// Decreases the buffer's offset by 2 and then reads an unsigned 16-bit integer
+    pub fn get_u16(&mut self) -> Result<u16> {
+        get_u_reverse!(self, u16, 2)
+    }
+
+    /// Decreases the buffer's offset by 3 and then reads 24 bits into an unsigned 32-bit integer
+    pub fn get_u24(&mut self) -> Result<u32> {
+        get_u_reverse!(self, u32, 3)
+    }
+
+    /// Decreases the buffer's offset by 4 and then reads an unsigned 32-bit integer
+    pub fn get_u32(&mut self) -> Result<u32> {
+        get_u_reverse!(self, u32, 4)
+    }
+
+    /// Decreases the buffer's offset by 8 and then reads an unsigned 64-bit integer
+    pub fn get_u64(&mut self) -> Result<u64> {
+        get_u_reverse!(self, u64, 8)
+    }
+
+    /// In reversed buffers, variable length integers also need to be
+    /// "reversed", with the 2-bits length indicator at the end of the first
+    /// byte in the backward direction.
+    /// Reads an unsigned variable-length integer in network byte-order from
+    /// the current offset and rewinds the buffer.
+    pub fn get_varint(&mut self) -> Result<u64> {
+        if_unlikely! { self.off == 0 => {
+            Err(BufferError::BufferProtocolError)
+        } else {
+            let last = self.peek_u8()?;
+            let len = varint_parse_len_reverse(last);
+            let out = match len {
+                1 => u64::from(self.get_u8()? >> 2),
+                2 => u64::from(self.get_u16() ? >> 2),
+                4 => u64::from(self.get_u32()? >> 2),
+                8 => self.get_u64()? >> 2,
+                _ => unreachable!(),
+            };
+            Ok(out)
+        }}
+    }
+
+    /// Rewind the buffer of  `len` bytes from the current offset and then
+    /// read without copying.
+    pub fn get_bytes(&mut self, len: usize) -> Result<Octets<'a>> {
+        if_unlikely! { self.off < len => {
+            Err(BufferError::BufferProtocolError)
+        } else {
+            self.off -= len;
+            let out = Octets {buf: &self.buf[self.off..self.off + len], off: 0};
+            Ok(out)
+        }}
+    }
+
+    /// Rewind the buffer of `len` bytes and read `len` bytes  without copying.
+    pub fn get_bytes_with_u8_length(&mut self) -> Result<Octets<'a>> {
+        let len = self.get_u8()?;
+        self.get_bytes(len as usize)
+    }
+
+    /// Rewind the buffer of `len`+ 2 bytes and read `len` bytes  without
+    /// copying.
+    pub fn get_bytes_with_u16_length(&mut self) -> Result<Octets<'a>> {
+        let len = self.get_u16()?;
+        self.get_bytes(len as usize)
+    }
+
+    /// Rewind the buffer of `len`+ varint bytes and read `len` bytes without
+    /// copying.
+    pub fn get_bytes_with_varint_length(&mut self) -> Result<Octets<'a>> {
+        let len = self.get_varint()?;
+        self.get_bytes(len as usize)
+    }
+
+    /// Advances the buffer's offset, moving the offset towars
+    /// lower values.
+    pub fn skip(&mut self, skip: usize) -> Result<()> {
+        if self.off < skip {
+            return Err(BufferError::BufferTooShortError);
+        }
+        self.off -= skip;
+        Ok(())
+    }
+
+    /// Rewinds the buffer's offset, moving the offset towards
+    /// higher values.
+    pub fn rewind(&mut self, rewind: usize) -> Result<()> {
+        if self.off < rewind {
+            return Err(BufferError::BufferTooShortError);
+        }
+        self.off += rewind;
+        Ok(())
+    }
+
+    pub fn cap(&self) -> usize {
+        self.off
+    }
+
+    /// Returns the total length of the buffer.
+    pub fn len(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Returns `true` if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.buf.len() == 0
+    }
+
+    /// Returns the current offset of the buffer.
+    pub fn off(&self) -> usize {
+        self.off
+    }
+
+    /// Returns a reference to the internal buffer.
+    pub fn buf(&self) -> &'a [u8] {
+        self.buf
+    }
+
+    /// Copies the buffer from the current offset into a new `Vec<u8>`.
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.as_ref().to_vec()
+    }
+}
+
+impl<'a> AsRef<[u8]> for OctetsRev<'a> {
+    fn as_ref(&self) -> &[u8] {
+        &self.buf[..self.off]
+    }
+}
+
+impl<'a> std::ops::Deref for OctetsRev<'a> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.buf[..self.off]
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct OctetsMutRev<'a> {
+    buf: &'a mut [u8],
+    off: usize,
+}
+
+impl<'a> OctetsMutRev<'a> {
+    pub fn with_slice(buf: &'a mut [u8]) -> Self {
+        let len = buf.len();
+        OctetsMutRev { buf, off: len }
+    }
+
+    /// Writes an unsigned 8-bit integer at the current offset and advances
+    /// the buffer.
+    pub fn put_u8(&mut self, v: u8) -> Result<&mut [u8]> {
+        put_u_reverse!(self, u8, v, 1)
+    }
+
+    pub fn put_u16(&mut self, v: u16) -> Result<&mut [u8]> {
+        put_u_reverse!(self, u16, v, 2)
+    }
+
+    pub fn put_u24(&mut self, v: u32) -> Result<&mut [u8]> {
+        put_u_reverse!(self, u32, v, 3)
+    }
+
+    pub fn put_u32(&mut self, v: u32) -> Result<&mut [u8]> {
+        put_u_reverse!(self, u32, v, 4)
+    }
+
+    pub fn put_u64(&mut self, v: u64) -> Result<&mut [u8]> {
+        put_u_reverse!(self, u64, v, 8)
+    }
+
+    #[inline]
+    pub fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
+        self.put_varint_with_len(v, varint_len(v))
+    }
+    #[inline]
+    pub fn put_varint_with_len(
+        &mut self, v: u64, len: usize,
+    ) -> Result<&mut [u8]> {
+        if self.cap() < len {
+            return Err(BufferError::BufferTooShortError);
+        }
+        let buf = match len {
+            1 => self.put_u8((v << 2) as u8)?,
+            2 => {
+                let buf = self.put_u16((v << 2) as u16)?;
+                buf[1] |= 0x1;
+                buf
+            },
+            4 => {
+                let buf = self.put_u32((v << 2) as u32)?;
+                buf[3] |= 0x2;
+                buf
+            },
+            8 => {
+                let buf = self.put_u64(v << 2)?;
+                buf[7] |= 0x3;
+                buf
+            },
+            _ => panic!("value is too large for varint"),
+        };
+        Ok(buf)
+    }
+
+    /// Writes `len` bytes from the current offset without copying and advances
+    /// the buffer.
+    pub fn put_bytes(&mut self, v: &[u8]) -> Result<()> {
+        let len = v.len();
+        if self.cap() < len {
+            return Err(BufferError::BufferTooShortError);
+        }
+        if len == 0 {
+            return Ok(());
+        }
+        self.off -= len;
+        self.buf[self.off..self.off + len].copy_from_slice(v);
+        Ok(())
+    }
+
+    /// Advances the buffer, moving the offet towards lower values.
+    pub fn skip(&mut self, skip: usize) -> Result<()> {
+        if self.off < skip {
+            return Err(BufferError::BufferTooShortError);
+        }
+        self.off -= skip;
+        Ok(())
+    }
+
+    /// Rewinds the buffer, moving the offet towards higher values.
+    pub fn rewind(&mut self, rewind: usize) -> Result<()> {
+        if self.off < rewind {
+            return Err(BufferError::BufferTooShortError);
+        }
+        self.off += rewind;
+        Ok(())
+    }
+
+    pub fn cap(&self) -> usize {
+        self.off
+    }
+
+    /// Returns the total length of the buffer.
+    pub fn len(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Returns `true` if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.buf.len() == 0
+    }
+
+    /// Returns the current offset of the buffer.
+    pub fn off(&self) -> usize {
+        self.off
+    }
+
+    /// Returns a reference to the internal buffer.
+    pub fn buf(&self) -> &[u8] {
+        self.buf
+    }
+
+    /// Copies the buffer from the current offset into a new `Vec<u8>`.
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.as_ref().to_vec()
+    }
+}
+
+impl<'a> AsRef<[u8]> for OctetsMutRev<'a> {
+    fn as_ref(&self) -> &[u8] {
+        &self.buf[..self.off]
+    }
+}
+
+impl<'a> AsMut<[u8]> for OctetsMutRev<'a> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[..self.off]
+    }
+}
+
+impl<'a> OctetsRead<'a> for Octets<'a> {
+    type Bytes = Octets<'a>;
+
+    #[inline]
+    fn get_u8(&mut self) -> Result<u8> {
+        Octets::get_u8(self)
+    }
+
+    #[inline]
+    fn get_u16(&mut self) -> Result<u16> {
+        Octets::get_u16(self)
+    }
+
+    #[inline]
+    fn get_u24(&mut self) -> Result<u32> {
+        Octets::get_u24(self)
+    }
+
+    #[inline]
+    fn get_u32(&mut self) -> Result<u32> {
+        Octets::get_u32(self)
+    }
+
+    #[inline]
+    fn get_u64(&mut self) -> Result<u64> {
+        Octets::get_u64(self)
+    }
+
+    #[inline]
+    fn get_varint(&mut self) -> Result<u64> {
+        Octets::get_varint(self)
+    }
+
+    #[inline]
+    fn get_bytes(&mut self, len: usize) -> Result<Self::Bytes> {
+        Octets::get_bytes(self, len)
+    }
+
+    #[inline]
+    fn get_bytes_with_u8_length(&mut self) -> Result<Self::Bytes> {
+        Octets::get_bytes_with_u8_length(self)
+    }
+
+    #[inline]
+    fn get_bytes_with_u16_length(&mut self) -> Result<Self::Bytes> {
+        Octets::get_bytes_with_u16_length(self)
+    }
+
+    #[inline]
+    fn get_bytes_with_varint_length(&mut self) -> Result<Self::Bytes> {
+        Octets::get_bytes_with_varint_length(self)
+    }
+
+    #[inline]
+    fn peek_u8(&mut self) -> Result<u8> {
+        Octets::peek_u8(self)
+    }
+
+    #[inline]
+    fn skip(&mut self, skip: usize) -> Result<()> {
+        Octets::skip(self, skip)
+    }
+
+    #[inline]
+    fn rewind(&mut self, rewind: usize) -> Result<()> {
+        Octets::rewind(self, rewind)
+    }
+
+    #[inline]
+    fn cap(&self) -> usize {
+        Octets::cap(self)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        Octets::len(self)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        Octets::is_empty(self)
+    }
+
+    #[inline]
+    fn off(&self) -> usize {
+        Octets::off(self)
+    }
+
+    #[inline]
+    fn buf(&self) -> &'a [u8] {
+        Octets::buf(self)
+    }
+
+    #[inline]
+    fn to_vec(&self) -> Vec<u8> {
+        Octets::to_vec(self)
+    }
+}
+
+impl<'a> OctetsRead<'a> for OctetsRev<'a> {
+    type Bytes = Octets<'a>;
+
+    #[inline]
+    fn get_u8(&mut self) -> Result<u8> {
+        OctetsRev::get_u8(self)
+    }
+
+    #[inline]
+    fn get_u16(&mut self) -> Result<u16> {
+        OctetsRev::get_u16(self)
+    }
+
+    #[inline]
+    fn get_u24(&mut self) -> Result<u32> {
+        OctetsRev::get_u24(self)
+    }
+
+    #[inline]
+    fn get_u32(&mut self) -> Result<u32> {
+        OctetsRev::get_u32(self)
+    }
+
+    #[inline]
+    fn get_u64(&mut self) -> Result<u64> {
+        OctetsRev::get_u64(self)
+    }
+
+    #[inline]
+    fn get_varint(&mut self) -> Result<u64> {
+        OctetsRev::get_varint(self)
+    }
+
+    #[inline]
+    fn get_bytes(&mut self, len: usize) -> Result<Self::Bytes> {
+        OctetsRev::get_bytes(self, len)
+    }
+
+    #[inline]
+    fn get_bytes_with_u8_length(&mut self) -> Result<Self::Bytes> {
+        OctetsRev::get_bytes_with_u8_length(self)
+    }
+
+    #[inline]
+    fn get_bytes_with_u16_length(&mut self) -> Result<Self::Bytes> {
+        OctetsRev::get_bytes_with_u16_length(self)
+    }
+
+    #[inline]
+    fn get_bytes_with_varint_length(&mut self) -> Result<Self::Bytes> {
+        OctetsRev::get_bytes_with_varint_length(self)
+    }
+
+    #[inline]
+    fn peek_u8(&mut self) -> Result<u8> {
+        OctetsRev::peek_u8(self)
+    }
+
+    #[inline]
+    fn skip(&mut self, skip: usize) -> Result<()> {
+        OctetsRev::skip(self, skip)
+    }
+
+    #[inline]
+    fn rewind(&mut self, rewind: usize) -> Result<()> {
+        OctetsRev::rewind(self, rewind)
+    }
+
+    #[inline]
+    fn cap(&self) -> usize {
+        OctetsRev::cap(self)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        OctetsRev::len(self)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        OctetsRev::is_empty(self)
+    }
+
+    #[inline]
+    fn off(&self) -> usize {
+        OctetsRev::off(self)
+    }
+
+    #[inline]
+    fn buf(&self) -> &'a [u8] {
+        OctetsRev::buf(self)
+    }
+
+    #[inline]
+    fn to_vec(&self) -> Vec<u8> {
+        OctetsRev::to_vec(self)
+    }
+}
+
+impl<'a> OctetsWrite<'a> for OctetsMut<'a> {
+    #[inline]
+    fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
+        OctetsMut::put_varint(self, v)
+    }
+
+    #[inline]
+    fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]> {
+        OctetsMut::put_varint_with_len(self, v, len)
+    }
+
+    #[inline]
+    fn skip(&mut self, skip: usize) -> Result<()> {
+        OctetsMut::skip(self, skip)
+    }
+
+    #[inline]
+    fn rewind(&mut self, rewind: usize) -> Result<()> {
+        OctetsMut::rewind(self, rewind)
+    }
+
+    #[inline]
+    fn cap(&self) -> usize {
+        OctetsMut::cap(self)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        OctetsMut::len(self)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        OctetsMut::is_empty(self)
+    }
+
+    #[inline]
+    fn off(&self) -> usize {
+        OctetsMut::off(self)
+    }
+
+    #[inline]
+    fn buf(&self) -> &[u8] {
+        OctetsMut::buf(self)
+    }
+
+    #[inline]
+    fn to_vec(&self) -> Vec<u8> {
+        OctetsMut::to_vec(self)
+    }
+}
+
+impl<'a> OctetsWrite<'a> for OctetsMutRev<'a> {
+    #[inline]
+    fn put_varint(&mut self, v: u64) -> Result<&mut [u8]> {
+        OctetsMutRev::put_varint(self, v)
+    }
+
+    #[inline]
+    fn put_varint_with_len(&mut self, v: u64, len: usize) -> Result<&mut [u8]> {
+        OctetsMutRev::put_varint_with_len(self, v, len)
+    }
+
+    #[inline]
+    fn skip(&mut self, skip: usize) -> Result<()> {
+        OctetsMutRev::skip(self, skip)
+    }
+
+    #[inline]
+    fn rewind(&mut self, rewind: usize) -> Result<()> {
+        OctetsMutRev::rewind(self, rewind)
+    }
+
+    #[inline]
+    fn cap(&self) -> usize {
+        OctetsMutRev::cap(self)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        OctetsMutRev::len(self)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        OctetsMutRev::is_empty(self)
+    }
+
+    #[inline]
+    fn off(&self) -> usize {
+        OctetsMutRev::off(self)
+    }
+
+    #[inline]
+    fn buf(&self) -> &[u8] {
+        OctetsMutRev::buf(self)
+    }
+
+    #[inline]
+    fn to_vec(&self) -> Vec<u8> {
+        OctetsMutRev::to_vec(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
     fn get_u() {
         let d = [
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         ];
-
         let mut b = Octets::with_slice(&d);
         assert_eq!(b.cap(), 18);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.get_u8().unwrap(), 1);
         assert_eq!(b.cap(), 17);
         assert_eq!(b.off(), 1);
-
         assert_eq!(b.get_u16().unwrap(), 0x203);
         assert_eq!(b.cap(), 15);
         assert_eq!(b.off(), 3);
-
         assert_eq!(b.get_u24().unwrap(), 0x40506);
         assert_eq!(b.cap(), 12);
         assert_eq!(b.off(), 6);
-
         assert_eq!(b.get_u32().unwrap(), 0x0708090a);
         assert_eq!(b.cap(), 8);
         assert_eq!(b.off(), 10);
-
         assert_eq!(b.get_u64().unwrap(), 0x0b0c0d0e0f101112);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 18);
-
         assert!(b.get_u8().is_err());
         assert!(b.get_u16().is_err());
         assert!(b.get_u24().is_err());
@@ -986,31 +1416,24 @@ mod tests {
         let mut d = [
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         ];
-
         let mut b = OctetsMut::with_slice(&mut d);
         assert_eq!(b.cap(), 18);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.get_u8().unwrap(), 1);
         assert_eq!(b.cap(), 17);
         assert_eq!(b.off(), 1);
-
         assert_eq!(b.get_u16().unwrap(), 0x203);
         assert_eq!(b.cap(), 15);
         assert_eq!(b.off(), 3);
-
         assert_eq!(b.get_u24().unwrap(), 0x40506);
         assert_eq!(b.cap(), 12);
         assert_eq!(b.off(), 6);
-
         assert_eq!(b.get_u32().unwrap(), 0x0708090a);
         assert_eq!(b.cap(), 8);
         assert_eq!(b.off(), 10);
-
         assert_eq!(b.get_u64().unwrap(), 0x0b0c0d0e0f101112);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 18);
-
         assert!(b.get_u8().is_err());
         assert!(b.get_u16().is_err());
         assert!(b.get_u24().is_err());
@@ -1021,42 +1444,32 @@ mod tests {
     #[test]
     fn peek_u() {
         let d = [1, 2];
-
         let mut b = Octets::with_slice(&d);
         assert_eq!(b.cap(), 2);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.peek_u8().unwrap(), 1);
         assert_eq!(b.cap(), 2);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.peek_u8().unwrap(), 1);
         assert_eq!(b.cap(), 2);
         assert_eq!(b.off(), 0);
-
         b.get_u16().unwrap();
-
         assert!(b.peek_u8().is_err());
     }
 
     #[test]
     fn peek_u_mut() {
         let mut d = [1, 2];
-
         let mut b = OctetsMut::with_slice(&mut d);
         assert_eq!(b.cap(), 2);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.peek_u8().unwrap(), 1);
         assert_eq!(b.cap(), 2);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.peek_u8().unwrap(), 1);
         assert_eq!(b.cap(), 2);
         assert_eq!(b.off(), 0);
-
         b.get_u16().unwrap();
-
         assert!(b.peek_u8().is_err());
     }
 
@@ -1066,23 +1479,18 @@ mod tests {
         let mut b = Octets::with_slice(&d);
         assert_eq!(b.cap(), 10);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.get_bytes(5).unwrap().as_ref(), [1, 2, 3, 4, 5]);
         assert_eq!(b.cap(), 5);
         assert_eq!(b.off(), 5);
-
         assert_eq!(b.get_bytes(3).unwrap().as_ref(), [6, 7, 8]);
         assert_eq!(b.cap(), 2);
         assert_eq!(b.off(), 8);
-
         assert!(b.get_bytes(3).is_err());
         assert_eq!(b.cap(), 2);
         assert_eq!(b.off(), 8);
-
         assert_eq!(b.get_bytes(2).unwrap().as_ref(), [9, 10]);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 10);
-
         assert!(b.get_bytes(2).is_err());
     }
 
@@ -1092,23 +1500,18 @@ mod tests {
         let mut b = OctetsMut::with_slice(&mut d);
         assert_eq!(b.cap(), 10);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.get_bytes(5).unwrap().as_ref(), [1, 2, 3, 4, 5]);
         assert_eq!(b.cap(), 5);
         assert_eq!(b.off(), 5);
-
         assert_eq!(b.get_bytes(3).unwrap().as_ref(), [6, 7, 8]);
         assert_eq!(b.cap(), 2);
         assert_eq!(b.off(), 8);
-
         assert!(b.get_bytes(3).is_err());
         assert_eq!(b.cap(), 2);
         assert_eq!(b.off(), 8);
-
         assert_eq!(b.get_bytes(2).unwrap().as_ref(), [9, 10]);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 10);
-
         assert!(b.get_bytes(2).is_err());
     }
 
@@ -1118,15 +1521,12 @@ mod tests {
         let mut b = Octets::with_slice(&d);
         assert_eq!(b.cap(), 10);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.peek_bytes(5).unwrap().as_ref(), [1, 2, 3, 4, 5]);
         assert_eq!(b.cap(), 10);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.peek_bytes(5).unwrap().as_ref(), [1, 2, 3, 4, 5]);
         assert_eq!(b.cap(), 10);
         assert_eq!(b.off(), 0);
-
         b.get_bytes(5).unwrap();
     }
 
@@ -1136,15 +1536,12 @@ mod tests {
         let mut b = OctetsMut::with_slice(&mut d);
         assert_eq!(b.cap(), 10);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.peek_bytes(5).unwrap().as_ref(), [1, 2, 3, 4, 5]);
         assert_eq!(b.cap(), 10);
         assert_eq!(b.off(), 0);
-
         assert_eq!(b.peek_bytes(5).unwrap().as_ref(), [1, 2, 3, 4, 5]);
         assert_eq!(b.cap(), 10);
         assert_eq!(b.off(), 0);
-
         b.get_bytes(5).unwrap();
     }
 
@@ -1155,25 +1552,21 @@ mod tests {
         assert_eq!(b.get_varint().unwrap(), 151288809941952652);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 8);
-
         let d = [0x9d, 0x7f, 0x3e, 0x7d];
         let mut b = Octets::with_slice(&d);
         assert_eq!(b.get_varint().unwrap(), 494878333);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 4);
-
         let d = [0x7b, 0xbd];
         let mut b = Octets::with_slice(&d);
         assert_eq!(b.get_varint().unwrap(), 15293);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 2);
-
         let d = [0x40, 0x25];
         let mut b = Octets::with_slice(&d);
         assert_eq!(b.get_varint().unwrap(), 37);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 2);
-
         let d = [0x25];
         let mut b = Octets::with_slice(&d);
         assert_eq!(b.get_varint().unwrap(), 37);
@@ -1182,31 +1575,25 @@ mod tests {
     }
 
     #[test]
-    fn get_varint_reverse() {
+    fn get_varint_rev_test() {
         let d = [0x24];
-        let mut b = Octets::with_slice(&d);
-        b.skip(1).expect("skip issue");
-        assert_eq!(b.get_varint_reverse().unwrap(), 9);
+        let mut b = OctetsRev::with_slice(&d);
+        assert_eq!(b.get_varint().unwrap(), 9);
         assert_eq!(b.off(), 0);
-
         let d = [0x25, 0x25];
-        let mut b = Octets::with_slice(&d);
-        b.skip(2).expect("skip issue");
-        assert_eq!(b.get_varint_reverse().unwrap(), 2377);
+        let mut b = OctetsRev::with_slice(&d);
+        assert_eq!(b.get_varint().unwrap(), 2377);
         assert_eq!(b.off(), 0);
-
         let d = [0x7b, 0x9d, 0x25, 0x16];
-        let mut b = Octets::with_slice(&d);
-        b.skip(4).expect("skip issue");
-        assert_eq!(b.get_varint_reverse().unwrap(), 518474053);
+        let mut b = OctetsRev::with_slice(&d);
+        assert_eq!(b.get_varint().unwrap(), 518474053);
         assert_eq!(b.off(), 0);
-
         let d = [0x19, 0xc2, 0x5e, 0x7b, 0x9d, 0x25, 0x16, 0x17];
-        let mut b = Octets::with_slice(&d);
-        b.skip(8).expect("skip issue");
-        assert_eq!(b.get_varint_reverse().unwrap(), 464037470360126853);
+        let mut b = OctetsRev::with_slice(&d);
+        assert_eq!(b.get_varint().unwrap(), 464037470360126853);
         assert_eq!(b.off(), 0);
     }
+
     #[test]
     fn get_varint_mut() {
         let mut d = [0xc2, 0x19, 0x7c, 0x5e, 0xff, 0x14, 0xe8, 0x8c];
@@ -1214,25 +1601,21 @@ mod tests {
         assert_eq!(b.get_varint().unwrap(), 151288809941952652);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 8);
-
         let mut d = [0x9d, 0x7f, 0x3e, 0x7d];
         let mut b = OctetsMut::with_slice(&mut d);
         assert_eq!(b.get_varint().unwrap(), 494878333);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 4);
-
         let mut d = [0x7b, 0xbd];
         let mut b = OctetsMut::with_slice(&mut d);
         assert_eq!(b.get_varint().unwrap(), 15293);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 2);
-
         let mut d = [0x40, 0x25];
         let mut b = OctetsMut::with_slice(&mut d);
         assert_eq!(b.get_varint().unwrap(), 37);
         assert_eq!(b.cap(), 0);
         assert_eq!(b.off(), 2);
-
         let mut d = [0x25];
         let mut b = OctetsMut::with_slice(&mut d);
         assert_eq!(b.get_varint().unwrap(), 37);
@@ -1251,7 +1634,6 @@ mod tests {
         }
         let exp = [0xc2, 0x19, 0x7c, 0x5e, 0xff, 0x14, 0xe8, 0x8c];
         assert_eq!(&d, &exp);
-
         let mut d = [0; 4];
         {
             let mut b = OctetsMut::with_slice(&mut d);
@@ -1261,7 +1643,6 @@ mod tests {
         }
         let exp = [0x9d, 0x7f, 0x3e, 0x7d];
         assert_eq!(&d, &exp);
-
         let mut d = [0; 2];
         {
             let mut b = OctetsMut::with_slice(&mut d);
@@ -1271,7 +1652,6 @@ mod tests {
         }
         let exp = [0x7b, 0xbd];
         assert_eq!(&d, &exp);
-
         let mut d = [0; 1];
         {
             let mut b = OctetsMut::with_slice(&mut d);
@@ -1281,7 +1661,6 @@ mod tests {
         }
         let exp = [0x25];
         assert_eq!(&d, &exp);
-
         let mut d = [0; 3];
         {
             let mut b = OctetsMut::with_slice(&mut d);
@@ -1294,43 +1673,40 @@ mod tests {
     }
 
     #[test]
-    fn put_varint_reverse() {
+    fn put_varint_rev_test() {
         let mut d = [0; 1];
         {
-            let mut b = OctetsMut::with_slice(&mut d);
-            assert!(b.put_varint_reverse(9).is_ok());
+            let mut b = OctetsMutRev::with_slice(&mut d);
+            assert!(b.put_varint(9).is_ok());
             assert_eq!(b.cap(), 0);
-            assert_eq!(b.off(), 1);
+            assert_eq!(b.off(), 0);
         }
         let exp = [0x24];
         assert_eq!(&d, &exp);
-
         let mut d = [0; 2];
         {
-            let mut b = OctetsMut::with_slice(&mut d);
-            assert!(b.put_varint_reverse(2377).is_ok());
+            let mut b = OctetsMutRev::with_slice(&mut d);
+            assert!(b.put_varint(2377).is_ok());
             assert_eq!(b.cap(), 0);
-            assert_eq!(b.off(), 2);
+            assert_eq!(b.off(), 0);
         }
         let exp = [0x25, 0x25];
         assert_eq!(&d, &exp);
-
         let mut d = [0; 4];
         {
-            let mut b = OctetsMut::with_slice(&mut d);
-            assert!(b.put_varint_reverse(518474053).is_ok());
+            let mut b = OctetsMutRev::with_slice(&mut d);
+            assert!(b.put_varint(518474053).is_ok());
             assert_eq!(b.cap(), 0);
-            assert_eq!(b.off(), 4);
+            assert_eq!(b.off(), 0);
         }
         let exp = [0x7b, 0x9d, 0x25, 0x16];
         assert_eq!(&d, &exp);
-
         let mut d = [0; 8];
         {
-            let mut b = OctetsMut::with_slice(&mut d);
-            assert!(b.put_varint_reverse(464037470360126853).is_ok());
+            let mut b = OctetsMutRev::with_slice(&mut d);
+            assert!(b.put_varint(464037470360126853).is_ok());
             assert_eq!(b.cap(), 0);
-            assert_eq!(b.off(), 8);
+            assert_eq!(b.off(), 0);
         }
         let exp = [0x19, 0xc2, 0x5e, 0x7b, 0x9d, 0x25, 0x16, 0x17];
         assert_eq!(&d, &exp);
@@ -1347,35 +1723,27 @@ mod tests {
     #[test]
     fn put_u() {
         let mut d = [0; 18];
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             assert_eq!(b.cap(), 18);
             assert_eq!(b.off(), 0);
-
             assert!(b.put_u8(1).is_ok());
             assert_eq!(b.cap(), 17);
             assert_eq!(b.off(), 1);
-
             assert!(b.put_u16(0x203).is_ok());
             assert_eq!(b.cap(), 15);
             assert_eq!(b.off(), 3);
-
             assert!(b.put_u24(0x40506).is_ok());
             assert_eq!(b.cap(), 12);
             assert_eq!(b.off(), 6);
-
             assert!(b.put_u32(0x0708090a).is_ok());
             assert_eq!(b.cap(), 8);
             assert_eq!(b.off(), 10);
-
             assert!(b.put_u64(0x0b0c0d0e0f101112).is_ok());
             assert_eq!(b.cap(), 0);
             assert_eq!(b.off(), 18);
-
             assert!(b.put_u8(1).is_err());
         }
-
         let exp = [
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
         ];
@@ -1385,20 +1753,16 @@ mod tests {
     #[test]
     fn put_bytes() {
         let mut d = [0; 5];
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             assert_eq!(b.cap(), 5);
             assert_eq!(b.off(), 0);
-
             let p = [0x0a, 0x0b, 0x0c, 0x0d, 0x0e];
             assert!(b.put_bytes(&p).is_ok());
             assert_eq!(b.cap(), 0);
             assert_eq!(b.off(), 5);
-
             assert!(b.put_u8(1).is_err());
         }
-
         let exp = [0xa, 0xb, 0xc, 0xd, 0xe];
         assert_eq!(&d, &exp);
     }
@@ -1406,24 +1770,19 @@ mod tests {
     #[test]
     fn split() {
         let mut d = b"helloworld".to_vec();
-
         let mut b = OctetsMut::with_slice(&mut d);
         assert_eq!(b.cap(), 10);
         assert_eq!(b.off(), 0);
         assert_eq!(b.as_ref(), b"helloworld");
-
         assert!(b.get_bytes(5).is_ok());
         assert_eq!(b.cap(), 5);
         assert_eq!(b.off(), 5);
         assert_eq!(b.as_ref(), b"world");
-
         let off = b.off();
-
         let (first, last) = b.split_at(off).unwrap();
         assert_eq!(first.cap(), 5);
         assert_eq!(first.off(), 0);
         assert_eq!(first.as_ref(), b"hello");
-
         assert_eq!(last.cap(), 5);
         assert_eq!(last.off(), 0);
         assert_eq!(last.as_ref(), b"world");
@@ -1432,40 +1791,30 @@ mod tests {
     #[test]
     fn split_at() {
         let mut d = b"helloworld".to_vec();
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             let (first, second) = b.split_at(5).unwrap();
-
             let mut exp1 = b"hello".to_vec();
             assert_eq!(first.as_ref(), &mut exp1[..]);
-
             let mut exp2 = b"world".to_vec();
             assert_eq!(second.as_ref(), &mut exp2[..]);
         }
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             let (first, second) = b.split_at(10).unwrap();
-
             let mut exp1 = b"helloworld".to_vec();
             assert_eq!(first.as_ref(), &mut exp1[..]);
-
             let mut exp2 = b"".to_vec();
             assert_eq!(second.as_ref(), &mut exp2[..]);
         }
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             let (first, second) = b.split_at(9).unwrap();
-
             let mut exp1 = b"helloworl".to_vec();
             assert_eq!(first.as_ref(), &mut exp1[..]);
-
             let mut exp2 = b"d".to_vec();
             assert_eq!(second.as_ref(), &mut exp2[..]);
         }
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             assert!(b.split_at(11).is_err());
@@ -1475,27 +1824,22 @@ mod tests {
     #[test]
     fn slice() {
         let d = b"helloworld".to_vec();
-
         {
             let b = Octets::with_slice(&d);
             let exp = b"hello".to_vec();
             assert_eq!(b.slice(5), Ok(&exp[..]));
         }
-
         {
             let b = Octets::with_slice(&d);
             let exp = b"".to_vec();
             assert_eq!(b.slice(0), Ok(&exp[..]));
         }
-
         {
             let mut b = Octets::with_slice(&d);
             b.get_bytes(5).unwrap();
-
             let exp = b"world".to_vec();
             assert_eq!(b.slice(5), Ok(&exp[..]));
         }
-
         {
             let b = Octets::with_slice(&d);
             assert!(b.slice(11).is_err());
@@ -1505,27 +1849,22 @@ mod tests {
     #[test]
     fn slice_mut() {
         let mut d = b"helloworld".to_vec();
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             let mut exp = b"hello".to_vec();
             assert_eq!(b.slice(5), Ok(&mut exp[..]));
         }
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             let mut exp = b"".to_vec();
             assert_eq!(b.slice(0), Ok(&mut exp[..]));
         }
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             b.get_bytes(5).unwrap();
-
             let mut exp = b"world".to_vec();
             assert_eq!(b.slice(5), Ok(&mut exp[..]));
         }
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             assert!(b.slice(11).is_err());
@@ -1535,31 +1874,26 @@ mod tests {
     #[test]
     fn slice_last() {
         let d = b"helloworld".to_vec();
-
         {
             let b = Octets::with_slice(&d);
             let exp = b"orld".to_vec();
             assert_eq!(b.slice_last(4), Ok(&exp[..]));
         }
-
         {
             let b = Octets::with_slice(&d);
             let exp = b"d".to_vec();
             assert_eq!(b.slice_last(1), Ok(&exp[..]));
         }
-
         {
             let b = Octets::with_slice(&d);
             let exp = b"".to_vec();
             assert_eq!(b.slice_last(0), Ok(&exp[..]));
         }
-
         {
             let b = Octets::with_slice(&d);
             let exp = b"helloworld".to_vec();
             assert_eq!(b.slice_last(10), Ok(&exp[..]));
         }
-
         {
             let b = Octets::with_slice(&d);
             assert!(b.slice_last(11).is_err());
@@ -1569,31 +1903,26 @@ mod tests {
     #[test]
     fn slice_last_mut() {
         let mut d = b"helloworld".to_vec();
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             let mut exp = b"orld".to_vec();
             assert_eq!(b.slice_last(4), Ok(&mut exp[..]));
         }
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             let mut exp = b"d".to_vec();
             assert_eq!(b.slice_last(1), Ok(&mut exp[..]));
         }
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             let mut exp = b"".to_vec();
             assert_eq!(b.slice_last(0), Ok(&mut exp[..]));
         }
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             let mut exp = b"helloworld".to_vec();
             assert_eq!(b.slice_last(10), Ok(&mut exp[..]));
         }
-
         {
             let mut b = OctetsMut::with_slice(&mut d);
             assert!(b.slice_last(11).is_err());

--- a/quiceh/Cargo.toml
+++ b/quiceh/Cargo.toml
@@ -60,7 +60,7 @@ intrusive-collections = "0.9.7"
 qlog = { version = "0.13", path = "../qlog", optional = true }
 sfv = { version = "0.9", optional = true }
 smallvec = { version = "1.15", features = ["serde", "union"] }
-branches = "0.4.3"
+branches = "0.4.4"
 itertools = "0.12.1"
 buffer-pool = "0.1.0"
 

--- a/quiceh/src/frame.rs
+++ b/quiceh/src/frame.rs
@@ -200,35 +200,21 @@ pub enum Frame {
 }
 
 impl Frame {
-    pub fn from_bytes(
-        b: &mut octets_rev::Octets, pkt: packet::Type, version: u32,
+    pub fn from_bytes<
+        'a,
+        T: octets_rev::OctetsRead<Bytes = octets_rev::Octets<'a>>,
+    >(
+        b: &mut T, pkt: packet::Type, version: u32,
     ) -> Result<Frame> {
-        let frame_type = if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-            b.get_varint_reverse()?
-        } else {
-            b.get_varint()?
-        };
-        // Parse frames according either to the V3 format or to the previous Quic
-        // format. In V3, frames are reversed, meaning that:
-        //  - Elements order is reversed
-        //  - Elements are encoded and decoded with the set of [..]_reverse()
-        //    Octets functions to enable reading them from the back of the buffer
-        //    towards the beginning (Manga-like).
+        let frame_type = b.get_varint()?;
+
         let frame: Frame = match frame_type {
             0x00 => {
                 let mut len = 1;
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    while b.peek_u8_reverse() == Ok(0x00) {
-                        b.get_u8_reverse()?;
+                while b.peek_u8() == Ok(0x00) {
+                    b.get_u8()?;
 
-                        len += 1;
-                    }
-                } else {
-                    while b.peek_u8() == Ok(0x00) {
-                        b.get_u8()?;
-
-                        len += 1;
-                    }
+                    len += 1;
                 }
 
                 Frame::Padding { len }
@@ -236,265 +222,129 @@ impl Frame {
 
             0x01 => Frame::Ping { mtu_probe: None },
 
-            0x02..=0x03 => parse_ack_frame(frame_type, b, version)?,
+            0x02..=0x03 => parse_ack_frame(frame_type, b)?,
 
-            0x04 => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    Frame::ResetStream {
-                        stream_id: b.get_varint_reverse()?,
-                        error_code: b.get_varint_reverse()?,
-                        final_size: b.get_varint_reverse()?,
-                    }
-                } else {
-                    Frame::ResetStream {
-                        stream_id: b.get_varint()?,
-                        error_code: b.get_varint()?,
-                        final_size: b.get_varint()?,
-                    }
-                }
+            0x04 => Frame::ResetStream {
+                stream_id: b.get_varint()?,
+                error_code: b.get_varint()?,
+                final_size: b.get_varint()?,
             },
 
-            0x05 => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    Frame::StopSending {
-                        stream_id: b.get_varint_reverse()?,
-                        error_code: b.get_varint_reverse()?,
-                    }
-                } else {
-                    Frame::StopSending {
-                        stream_id: b.get_varint()?,
-                        error_code: b.get_varint()?,
-                    }
-                }
+            0x05 => Frame::StopSending {
+                stream_id: b.get_varint()?,
+                error_code: b.get_varint()?,
             },
 
             0x06 => {
                 let (offset, data) =
-                    if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                        (
-                            b.get_varint_reverse()?,
-                            b.get_bytes_with_varint_length_reverse()?,
-                        )
-                    } else {
-                        (b.get_varint()?, b.get_bytes_with_varint_length()?)
-                    };
-                // TODO protocol reverso could get rid of RangeBuf.
+                    (b.get_varint()?, b.get_bytes_with_varint_length()?);
+
                 let data = <RangeBuf>::from(data.as_ref(), offset, false);
 
                 Frame::Crypto { data }
             },
 
             0x07 => Frame::NewToken {
-                token: if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    let len = b.get_varint_reverse()?;
-                    if len == 0 {
-                        return Err(Error::InvalidFrame);
-                    }
-                    b.get_bytes_reverse(len as usize)?.to_vec()
-                } else {
+                token: {
                     let len = b.get_varint()?;
                     if len == 0 {
                         return Err(Error::InvalidFrame);
                     }
-                    b.get_bytes(len as usize)?.to_vec()
+                    b.get_bytes(len as usize)?.as_ref().to_vec()
                 },
             },
 
             0x08..=0x0f => parse_stream_frame(frame_type, b, version)?,
 
             0x10 => Frame::MaxData {
-                max: if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.get_varint_reverse()?
-                } else {
-                    b.get_varint()?
-                },
+                max: b.get_varint()?,
             },
 
-            0x11 => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    Frame::MaxStreamData {
-                        stream_id: b.get_varint_reverse()?,
-                        max: b.get_varint_reverse()?,
-                    }
-                } else {
-                    Frame::MaxStreamData {
-                        stream_id: b.get_varint()?,
-                        max: b.get_varint()?,
-                    }
-                }
+            0x11 => Frame::MaxStreamData {
+                stream_id: b.get_varint()?,
+                max: b.get_varint()?,
             },
 
             0x12 => Frame::MaxStreamsBidi {
-                max: if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.get_varint_reverse()?
-                } else {
-                    b.get_varint()?
-                },
+                max: b.get_varint()?,
             },
 
             0x13 => Frame::MaxStreamsUni {
-                max: if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.get_varint_reverse()?
-                } else {
-                    b.get_varint()?
-                },
+                max: b.get_varint()?,
             },
 
             0x14 => Frame::DataBlocked {
-                limit: if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.get_varint_reverse()?
-                } else {
-                    b.get_varint()?
-                },
+                limit: b.get_varint()?,
             },
 
-            0x15 => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    Frame::StreamDataBlocked {
-                        stream_id: b.get_varint_reverse()?,
-                        limit: b.get_varint_reverse()?,
-                    }
-                } else {
-                    Frame::StreamDataBlocked {
-                        stream_id: b.get_varint()?,
-                        limit: b.get_varint()?,
-                    }
-                }
+            0x15 => Frame::StreamDataBlocked {
+                stream_id: b.get_varint()?,
+                limit: b.get_varint()?,
             },
 
             0x16 => Frame::StreamsBlockedBidi {
-                limit: if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.get_varint_reverse()?
-                } else {
-                    b.get_varint()?
-                },
+                limit: b.get_varint()?,
             },
 
             0x17 => Frame::StreamsBlockedUni {
-                limit: if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.get_varint_reverse()?
-                } else {
-                    b.get_varint()?
-                },
+                limit: b.get_varint()?,
             },
 
             0x18 => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    let seq_num = b.get_varint_reverse()?;
-                    let retire_prior_to = b.get_varint_reverse()?;
-                    let conn_id_len = b.get_u8_reverse()?;
+                let seq_num = b.get_varint()?;
+                let retire_prior_to = b.get_varint()?;
+                let conn_id_len = b.get_u8()?;
 
-                    if !(1..=packet::MAX_CID_LEN).contains(&conn_id_len) {
-                        return Err(Error::InvalidFrame);
-                    }
+                if !(1..=packet::MAX_CID_LEN).contains(&conn_id_len) {
+                    return Err(Error::InvalidFrame);
+                }
 
-                    Frame::NewConnectionId {
-                        seq_num,
-                        retire_prior_to,
-                        conn_id: b
-                            .get_bytes_reverse(conn_id_len as usize)?
-                            .to_vec(),
-                        reset_token: b
-                            .get_bytes_reverse(16)?
-                            .buf()
-                            .try_into()
-                            .map_err(|_| Error::BufferTooShort)?,
-                    }
-                } else {
-                    let seq_num = b.get_varint()?;
-                    let retire_prior_to = b.get_varint()?;
-                    let conn_id_len = b.get_u8()?;
-
-                    if !(1..=packet::MAX_CID_LEN).contains(&conn_id_len) {
-                        return Err(Error::InvalidFrame);
-                    }
-
-                    Frame::NewConnectionId {
-                        seq_num,
-                        retire_prior_to,
-                        conn_id: b.get_bytes(conn_id_len as usize)?.to_vec(),
-                        reset_token: b
-                            .get_bytes(16)?
-                            .buf()
-                            .try_into()
-                            .map_err(|_| Error::BufferTooShort)?,
-                    }
+                Frame::NewConnectionId {
+                    seq_num,
+                    retire_prior_to,
+                    conn_id: b.get_bytes(conn_id_len as usize)?.as_ref().to_vec(),
+                    reset_token: b
+                        .get_bytes(16)?
+                        .as_ref()
+                        .try_into()
+                        .map_err(|_| Error::BufferTooShort)?,
                 }
             },
 
             0x19 => Frame::RetireConnectionId {
-                seq_num: if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.get_varint_reverse()?
-                } else {
-                    b.get_varint()?
-                },
+                seq_num: b.get_varint()?,
             },
 
             0x1a => Frame::PathChallenge {
-                data: if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.get_bytes_reverse(8)?
-                        .buf()
-                        .try_into()
-                        .map_err(|_| Error::BufferTooShort)?
-                } else {
-                    b.get_bytes(8)?
-                        .buf()
-                        .try_into()
-                        .map_err(|_| Error::BufferTooShort)?
-                },
+                data: b
+                    .get_bytes(8)?
+                    .as_ref()
+                    .try_into()
+                    .map_err(|_| Error::BufferTooShort)?,
             },
 
             0x1b => Frame::PathResponse {
-                data: if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.get_bytes_reverse(8)?
-                        .buf()
-                        .try_into()
-                        .map_err(|_| Error::BufferTooShort)?
-                } else {
-                    b.get_bytes(8)?
-                        .buf()
-                        .try_into()
-                        .map_err(|_| Error::BufferTooShort)?
-                },
+                data: b
+                    .get_bytes(8)?
+                    .as_ref()
+                    .try_into()
+                    .map_err(|_| Error::BufferTooShort)?,
             },
 
-            0x1c => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    Frame::ConnectionClose {
-                        error_code: b.get_varint_reverse()?,
-                        frame_type: b.get_varint_reverse()?,
-                        reason: b
-                            .get_bytes_with_varint_length_reverse()?
-                            .to_vec(),
-                    }
-                } else {
-                    Frame::ConnectionClose {
-                        error_code: b.get_varint()?,
-                        frame_type: b.get_varint()?,
-                        reason: b.get_bytes_with_varint_length()?.to_vec(),
-                    }
-                }
+            0x1c => Frame::ConnectionClose {
+                error_code: b.get_varint()?,
+                frame_type: b.get_varint()?,
+                reason: b.get_bytes_with_varint_length()?.as_ref().to_vec(),
             },
 
-            0x1d => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    Frame::ApplicationClose {
-                        error_code: b.get_varint_reverse()?,
-                        reason: b
-                            .get_bytes_with_varint_length_reverse()?
-                            .to_vec(),
-                    }
-                } else {
-                    Frame::ApplicationClose {
-                        error_code: b.get_varint()?,
-                        reason: b.get_bytes_with_varint_length()?.to_vec(),
-                    }
-                }
+            0x1d => Frame::ApplicationClose {
+                error_code: b.get_varint()?,
+                reason: b.get_bytes_with_varint_length()?.as_ref().to_vec(),
             },
 
             0x1e => Frame::HandshakeDone,
 
-            0x30 | 0x31 => parse_datagram_frame(frame_type, b, version)?,
+            0x30 | 0x31 => parse_datagram_frame(frame_type, b)?,
 
             _ => return Err(Error::InvalidFrame),
         };
@@ -534,8 +384,8 @@ impl Frame {
         Ok(frame)
     }
 
-    pub fn to_bytes(
-        &self, b: &mut octets_rev::OctetsMut, version: u32,
+    pub fn to_bytes<T: octets_rev::OctetsWrite>(
+        &self, b: &mut T,
     ) -> Result<usize> {
         let before = b.cap();
 
@@ -544,21 +394,13 @@ impl Frame {
                 let mut left = *len;
 
                 while left > 0 {
-                    if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                        b.put_varint_reverse(0x00)?;
-                    } else {
-                        b.put_varint(0x00)?;
-                    }
+                    b.put_varint(0x00)?;
                     left -= 1;
                 }
             },
 
             Frame::Ping { .. } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(0x01)?;
-                } else {
-                    b.put_varint(0x01)?;
-                }
+                b.put_varint(0x01)?;
             },
 
             Frame::ACK {
@@ -566,89 +408,38 @@ impl Frame {
                 ranges,
                 ecn_counts,
             } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    // ecn first
-                    if let Some(ecn) = ecn_counts {
-                        b.put_varint_reverse(ecn.ecn_ce_count)?;
-                        b.put_varint_reverse(ecn.ect1_count)?;
-                        b.put_varint_reverse(ecn.ect0_count)?;
-                    }
-                    // This is a bit more mindtricking. On V1, ack ranges
-                    // are actually reversed to start reading from the largest_ack.
-                    // On V3, we can put the acks on the natural ordering, since it
-                    // is read backwards.
-                    let mut it = ranges.iter();
-                    let first = it.next().unwrap();
-                    let len = it.len();
-                    let last = it.next_back();
-                    let mut smallest_ack_end = first.end;
-                    let mut ack_block = (first.end - 1) - first.start;
-                    for block in it {
-                        let gap = block.start - smallest_ack_end - 1;
-                        b.put_varint_reverse(ack_block)?;
-                        b.put_varint_reverse(gap)?;
-                        ack_block = (block.end - 1) - block.start;
-                        smallest_ack_end = block.end;
-                    }
-                    // XXX Is there a better implementation possible to eliminate the control flow
-                    // for the last element?
-                    if let Some(block) = last {
-                        // last
-                        let gap = block.start - smallest_ack_end - 1;
-                        b.put_varint_reverse(ack_block)?;
-                        b.put_varint_reverse(gap)?;
-                        ack_block = (block.end - 1) - block.start;
-                        b.put_varint_reverse(ack_block)?;
-                        b.put_varint_reverse(len as u64)?;
-                        b.put_varint_reverse(*ack_delay)?;
-                        b.put_varint_reverse(block.end - 1)?;
-                    } else {
-                        // We actually just had one element
-                        b.put_varint_reverse(ack_block)?;
-                        b.put_varint_reverse(len as u64)?;
-                        b.put_varint_reverse(*ack_delay)?;
-                        b.put_varint_reverse(first.end - 1)?;
-                    }
-
-                    if ecn_counts.is_none() {
-                        b.put_varint_reverse(0x02)?;
-                    } else {
-                        b.put_varint_reverse(0x03)?;
-                    }
+                if ecn_counts.is_none() {
+                    b.put_varint(0x02)?;
                 } else {
-                    if ecn_counts.is_none() {
-                        b.put_varint(0x02)?;
-                    } else {
-                        b.put_varint(0x03)?;
-                    }
+                    b.put_varint(0x03)?;
+                }
 
-                    let mut it = ranges.iter().rev();
+                let mut it = ranges.iter().rev();
 
-                    let first = it.next().unwrap();
-                    let ack_block = (first.end - 1) - first.start;
+                let first = it.next().unwrap();
+                let ack_block = (first.end - 1) - first.start;
 
-                    b.put_varint(first.end - 1)?;
-                    b.put_varint(*ack_delay)?;
-                    b.put_varint(it.len() as u64)?;
+                b.put_varint(first.end - 1)?;
+                b.put_varint(*ack_delay)?;
+                b.put_varint(it.len() as u64)?;
+                b.put_varint(ack_block)?;
+
+                let mut smallest_ack = first.start;
+
+                for block in it {
+                    let gap = smallest_ack - block.end - 1;
+                    let ack_block = (block.end - 1) - block.start;
+
+                    b.put_varint(gap)?;
                     b.put_varint(ack_block)?;
 
-                    let mut smallest_ack = first.start;
+                    smallest_ack = block.start;
+                }
 
-                    for block in it {
-                        let gap = smallest_ack - block.end - 1;
-                        let ack_block = (block.end - 1) - block.start;
-
-                        b.put_varint(gap)?;
-                        b.put_varint(ack_block)?;
-
-                        smallest_ack = block.start;
-                    }
-
-                    if let Some(ecn) = ecn_counts {
-                        b.put_varint(ecn.ect0_count)?;
-                        b.put_varint(ecn.ect1_count)?;
-                        b.put_varint(ecn.ecn_ce_count)?;
-                    }
+                if let Some(ecn) = ecn_counts {
+                    b.put_varint(ecn.ect0_count)?;
+                    b.put_varint(ecn.ect1_count)?;
+                    b.put_varint(ecn.ecn_ce_count)?;
                 }
             },
 
@@ -657,194 +448,104 @@ impl Frame {
                 error_code,
                 final_size,
             } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*final_size)?;
-                    b.put_varint_reverse(*error_code)?;
-                    b.put_varint_reverse(*stream_id)?;
+                b.put_varint(0x04)?;
 
-                    b.put_varint_reverse(0x04)?;
-                } else {
-                    b.put_varint(0x04)?;
-
-                    b.put_varint(*stream_id)?;
-                    b.put_varint(*error_code)?;
-                    b.put_varint(*final_size)?;
-                }
+                b.put_varint(*stream_id)?;
+                b.put_varint(*error_code)?;
+                b.put_varint(*final_size)?;
             },
 
             Frame::StopSending {
                 stream_id,
                 error_code,
             } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*error_code)?;
-                    b.put_varint_reverse(*stream_id)?;
+                b.put_varint(0x05)?;
 
-                    b.put_varint_reverse(0x05)?;
-                } else {
-                    b.put_varint(0x05)?;
-
-                    b.put_varint(*stream_id)?;
-                    b.put_varint(*error_code)?;
-                };
+                b.put_varint(*stream_id)?;
+                b.put_varint(*error_code)?;
             },
 
             Frame::Crypto { data } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_bytes(data)?;
+                encode_crypto_header(data.off(), data.len() as u64, b)?;
 
-                    encode_crypto_footer(data.off(), data.len() as u64, b)?;
-                } else {
-                    encode_crypto_header(data.off(), data.len() as u64, b)?;
-
-                    b.put_bytes(data)?;
-                }
+                b.put_bytes(data)?;
             },
 
             Frame::CryptoHeader { .. } => (),
             Frame::CryptoVec { .. } => (),
 
             Frame::NewToken { token } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_bytes(token)?;
-                    b.put_varint_reverse(token.len() as u64)?;
+                b.put_varint(0x07)?;
 
-                    b.put_varint_reverse(0x07)?;
-                } else {
-                    b.put_varint(0x07)?;
-
-                    b.put_varint(token.len() as u64)?;
-                    b.put_bytes(token)?;
-                }
+                b.put_varint(token.len() as u64)?;
+                b.put_bytes(token)?;
             },
 
             // We don't use it to send data; we only use that for some test.
             Frame::StreamV3 { .. } => (),
 
             Frame::Stream { stream_id, data } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_bytes(data)?;
+                encode_stream_header(
+                    *stream_id,
+                    data.off(),
+                    data.len() as u64,
+                    data.fin(),
+                    b,
+                )?;
 
-                    encode_stream_footer(
-                        *stream_id,
-                        data.off(),
-                        data.len() as u64,
-                        data.fin(),
-                        b,
-                    )?;
-                } else {
-                    encode_stream_header(
-                        *stream_id,
-                        data.off(),
-                        data.len() as u64,
-                        data.fin(),
-                        b,
-                    )?;
-
-                    b.put_bytes(data)?;
-                }
+                b.put_bytes(data)?;
             },
 
             Frame::StreamHeader { .. } => (),
 
             Frame::MaxData { max } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*max)?;
+                b.put_varint(0x10)?;
 
-                    b.put_varint_reverse(0x10)?;
-                } else {
-                    b.put_varint(0x10)?;
-
-                    b.put_varint(*max)?;
-                }
+                b.put_varint(*max)?;
             },
 
             Frame::MaxStreamData { stream_id, max } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*max)?;
-                    b.put_varint_reverse(*stream_id)?;
+                b.put_varint(0x11)?;
 
-                    b.put_varint_reverse(0x11)?;
-                } else {
-                    b.put_varint(0x11)?;
-
-                    b.put_varint(*stream_id)?;
-                    b.put_varint(*max)?;
-                }
+                b.put_varint(*stream_id)?;
+                b.put_varint(*max)?;
             },
 
             Frame::MaxStreamsBidi { max } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*max)?;
+                b.put_varint(0x12)?;
 
-                    b.put_varint_reverse(0x12)?;
-                } else {
-                    b.put_varint(0x12)?;
-
-                    b.put_varint(*max)?;
-                }
+                b.put_varint(*max)?;
             },
 
             Frame::MaxStreamsUni { max } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*max)?;
+                b.put_varint(0x13)?;
 
-                    b.put_varint_reverse(0x13)?;
-                } else {
-                    b.put_varint(0x13)?;
-
-                    b.put_varint(*max)?;
-                }
+                b.put_varint(*max)?;
             },
 
             Frame::DataBlocked { limit } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*limit)?;
+                b.put_varint(0x14)?;
 
-                    b.put_varint_reverse(0x14)?;
-                } else {
-                    b.put_varint(0x14)?;
-
-                    b.put_varint(*limit)?;
-                }
+                b.put_varint(*limit)?;
             },
 
             Frame::StreamDataBlocked { stream_id, limit } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*limit)?;
-                    b.put_varint_reverse(*stream_id)?;
+                b.put_varint(0x15)?;
 
-                    b.put_varint_reverse(0x15)?;
-                } else {
-                    b.put_varint(0x15)?;
-
-                    b.put_varint(*stream_id)?;
-                    b.put_varint(*limit)?;
-                }
+                b.put_varint(*stream_id)?;
+                b.put_varint(*limit)?;
             },
 
             Frame::StreamsBlockedBidi { limit } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*limit)?;
+                b.put_varint(0x16)?;
 
-                    b.put_varint_reverse(0x16)?;
-                } else {
-                    b.put_varint(0x16)?;
-
-                    b.put_varint(*limit)?;
-                }
+                b.put_varint(*limit)?;
             },
 
             Frame::StreamsBlockedUni { limit } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*limit)?;
+                b.put_varint(0x17)?;
 
-                    b.put_varint_reverse(0x17)?;
-                } else {
-                    b.put_varint(0x17)?;
-
-                    b.put_varint(*limit)?;
-                }
+                b.put_varint(*limit)?;
             },
 
             Frame::NewConnectionId {
@@ -853,59 +554,31 @@ impl Frame {
                 conn_id,
                 reset_token,
             } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_bytes(reset_token.as_ref())?;
-                    b.put_bytes(conn_id.as_ref())?;
-                    b.put_u8(conn_id.len() as u8)?;
-                    b.put_varint_reverse(*retire_prior_to)?;
-                    b.put_varint_reverse(*seq_num)?;
+                b.put_varint(0x18)?;
 
-                    b.put_varint_reverse(0x18)?;
-                } else {
-                    b.put_varint(0x18)?;
-
-                    b.put_varint(*seq_num)?;
-                    b.put_varint(*retire_prior_to)?;
-                    b.put_u8(conn_id.len() as u8)?;
-                    b.put_bytes(conn_id.as_ref())?;
-                    b.put_bytes(reset_token.as_ref())?;
-                }
+                b.put_varint(*seq_num)?;
+                b.put_varint(*retire_prior_to)?;
+                b.put_u8(conn_id.len() as u8)?;
+                b.put_bytes(conn_id.as_ref())?;
+                b.put_bytes(reset_token.as_ref())?;
             },
 
             Frame::RetireConnectionId { seq_num } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(*seq_num)?;
+                b.put_varint(0x19)?;
 
-                    b.put_varint_reverse(0x19)?;
-                } else {
-                    b.put_varint(0x19)?;
-
-                    b.put_varint(*seq_num)?;
-                }
+                b.put_varint(*seq_num)?;
             },
 
             Frame::PathChallenge { data } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_bytes(data.as_ref())?;
+                b.put_varint(0x1a)?;
 
-                    b.put_varint_reverse(0x1a)?;
-                } else {
-                    b.put_varint(0x1a)?;
-
-                    b.put_bytes(data.as_ref())?;
-                }
+                b.put_bytes(data.as_ref())?;
             },
 
             Frame::PathResponse { data } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_bytes(data.as_ref())?;
+                b.put_varint(0x1b)?;
 
-                    b.put_varint_reverse(0x1b)?;
-                } else {
-                    b.put_varint(0x1b)?;
-
-                    b.put_bytes(data.as_ref())?;
-                }
+                b.put_bytes(data.as_ref())?;
             },
 
             Frame::ConnectionClose {
@@ -913,58 +586,30 @@ impl Frame {
                 frame_type,
                 reason,
             } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_bytes(reason.as_ref())?;
-                    b.put_varint_reverse(reason.len() as u64)?;
-                    b.put_varint_reverse(*frame_type)?;
-                    b.put_varint_reverse(*error_code)?;
+                b.put_varint(0x1c)?;
 
-                    b.put_varint_reverse(0x1c)?;
-                } else {
-                    b.put_varint(0x1c)?;
-
-                    b.put_varint(*error_code)?;
-                    b.put_varint(*frame_type)?;
-                    b.put_varint(reason.len() as u64)?;
-                    b.put_bytes(reason.as_ref())?;
-                }
+                b.put_varint(*error_code)?;
+                b.put_varint(*frame_type)?;
+                b.put_varint(reason.len() as u64)?;
+                b.put_bytes(reason.as_ref())?;
             },
 
             Frame::ApplicationClose { error_code, reason } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_bytes(reason.as_ref())?;
+                b.put_varint(0x1d)?;
 
-                    b.put_varint_reverse(reason.len() as u64)?;
-                    b.put_varint_reverse(*error_code)?;
-
-                    b.put_varint_reverse(0x1d)?;
-                } else {
-                    b.put_varint(0x1d)?;
-
-                    b.put_varint(*error_code)?;
-                    b.put_varint(reason.len() as u64)?;
-                    b.put_bytes(reason.as_ref())?;
-                }
+                b.put_varint(*error_code)?;
+                b.put_varint(reason.len() as u64)?;
+                b.put_bytes(reason.as_ref())?;
             },
 
             Frame::HandshakeDone => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_varint_reverse(0x1e)?;
-                } else {
-                    b.put_varint(0x1e)?;
-                }
+                b.put_varint(0x1e)?;
             },
 
             Frame::Datagram { data } => {
-                if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-                    b.put_bytes(data.as_ref())?;
+                encode_dgram_header(data.len() as u64, b)?;
 
-                    encode_dgram_footer(data.len() as u64, b)?;
-                } else {
-                    encode_dgram_header(data.len() as u64, b)?;
-
-                    b.put_bytes(data.as_ref())?;
-                }
+                b.put_bytes(data.as_ref())?;
             },
 
             Frame::DatagramHeader { .. } => (),
@@ -1634,27 +1279,17 @@ impl std::fmt::Debug for Frame {
 }
 
 fn parse_ack_frame(
-    ty: u64, b: &mut octets_rev::Octets, version: u32,
+    ty: u64, b: &mut impl octets_rev::OctetsRead,
 ) -> Result<Frame> {
     let first = ty as u8;
     let mut ranges = ranges::RangeSet::default();
 
-    let (largest_ack, ack_delay, block_count, ack_block) =
-        if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-            (
-                b.get_varint_reverse()?,
-                b.get_varint_reverse()?,
-                b.get_varint_reverse()?,
-                b.get_varint_reverse()?,
-            )
-        } else {
-            (
-                b.get_varint()?,
-                b.get_varint()?,
-                b.get_varint()?,
-                b.get_varint()?,
-            )
-        };
+    let (largest_ack, ack_delay, block_count, ack_block) = (
+        b.get_varint()?,
+        b.get_varint()?,
+        b.get_varint()?,
+        b.get_varint()?,
+    );
 
     if largest_ack < ack_block {
         return Err(Error::InvalidFrame);
@@ -1665,22 +1300,14 @@ fn parse_ack_frame(
     ranges.insert(smallest_ack..largest_ack + 1);
 
     for _ in 0..block_count {
-        let gap = if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-            b.get_varint_reverse()?
-        } else {
-            b.get_varint()?
-        };
+        let gap = b.get_varint()?;
 
         if smallest_ack < 2 + gap {
             return Err(Error::InvalidFrame);
         }
 
         let largest_ack = (smallest_ack - gap) - 2;
-        let ack_block = if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-            b.get_varint_reverse()?
-        } else {
-            b.get_varint()?
-        };
+        let ack_block = b.get_varint()?;
 
         if largest_ack < ack_block {
             return Err(Error::InvalidFrame);
@@ -1692,18 +1319,10 @@ fn parse_ack_frame(
     }
 
     let ecn_counts = if first & 0x01 != 0 {
-        let ecn = if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-            EcnCounts {
-                ect0_count: b.get_varint_reverse()?,
-                ect1_count: b.get_varint_reverse()?,
-                ecn_ce_count: b.get_varint_reverse()?,
-            }
-        } else {
-            EcnCounts {
-                ect0_count: b.get_varint()?,
-                ect1_count: b.get_varint()?,
-                ecn_ce_count: b.get_varint()?,
-            }
+        let ecn = EcnCounts {
+            ect0_count: b.get_varint()?,
+            ect1_count: b.get_varint()?,
+            ecn_ce_count: b.get_varint()?,
         };
         Some(ecn)
     } else {
@@ -1717,8 +1336,8 @@ fn parse_ack_frame(
     })
 }
 
-pub fn encode_crypto_header(
-    offset: u64, length: u64, b: &mut octets_rev::OctetsMut,
+pub fn encode_crypto_header<T: octets_rev::OctetsWrite>(
+    offset: u64, length: u64, b: &mut T,
 ) -> Result<()> {
     b.put_varint(0x06)?;
 
@@ -1730,21 +1349,8 @@ pub fn encode_crypto_header(
     Ok(())
 }
 
-pub fn encode_crypto_footer(
-    offset: u64, length: u64, b: &mut octets_rev::OctetsMut,
-) -> Result<()> {
-    b.put_varint_with_len_reverse(length, 2)?;
-
-    b.put_varint_reverse(offset)?;
-
-    b.put_varint_reverse(0x06)?;
-
-    Ok(())
-}
-
-pub fn encode_stream_header(
-    stream_id: u64, offset: u64, length: u64, fin: bool,
-    b: &mut octets_rev::OctetsMut,
+pub fn encode_stream_header<T: octets_rev::OctetsWrite>(
+    stream_id: u64, offset: u64, length: u64, fin: bool, b: &mut T,
 ) -> Result<()> {
     let mut ty: u8 = 0x08;
 
@@ -1764,47 +1370,9 @@ pub fn encode_stream_header(
     b.put_varint_with_len(length, 2)?;
     Ok(())
 }
-pub fn encode_stream_footer(
-    stream_id: u64, offset: u64, length: u64, fin: bool,
-    b: &mut octets_rev::OctetsMut,
-) -> Result<()> {
-    let mut ty: u8 = 0x08;
-
-    // Always encode offset.
-    ty |= 0x04;
-
-    // Always encode length.
-    ty |= 0x02;
-
-    if fin {
-        ty |= 0x01;
-    }
-    // Always encode length field as 2-byte varint.
-    b.put_varint_with_len_reverse(length, 2)?;
-    b.put_varint_reverse(offset)?;
-    b.put_varint_reverse(stream_id)?;
-
-    b.put_varint_reverse(u64::from(ty))?;
-
-    Ok(())
-}
-
-pub fn encode_dgram_footer(
-    length: u64, b: &mut octets_rev::OctetsMut,
-) -> Result<()> {
-    let mut ty: u8 = 0x30;
-
-    // Always encode length
-    ty |= 0x01;
-
-    b.put_varint_with_len_reverse(length, 2)?;
-    b.put_varint_reverse(u64::from(ty))?;
-
-    Ok(())
-}
 
 pub fn encode_dgram_header(
-    length: u64, b: &mut octets_rev::OctetsMut,
+    length: u64, b: &mut impl octets_rev::OctetsWrite,
 ) -> Result<()> {
     let mut ty: u8 = 0x30;
 
@@ -1820,33 +1388,35 @@ pub fn encode_dgram_header(
 }
 
 fn parse_stream_frame(
-    ty: u64, b: &mut octets_rev::Octets, version: u32,
+    ty: u64, b: &mut impl octets_rev::OctetsRead, version: u32,
 ) -> Result<Frame> {
     let first = ty as u8;
 
+    let stream_id = b.get_varint()?;
+
+    let offset = if first & 0x04 != 0 {
+        b.get_varint()?
+    } else {
+        0
+    };
+
+    let len = if first & 0x02 != 0 {
+        b.get_varint()? as usize
+    } else {
+        b.cap()
+    };
+
+    if offset + len as u64 >= MAX_STREAM_SIZE {
+        return Err(Error::InvalidFrame);
+    }
+
+    let fin = first & 0x01 != 0;
     if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-        let stream_id = b.get_varint_reverse()?;
-
-        let offset = if first & 0x04 != 0 {
-            b.get_varint_reverse()?
-        } else {
-            0
-        };
-
-        let len = if first & 0x02 != 0 {
-            b.get_varint_reverse()? as usize
-        } else {
-            // should be all bytes until the begining of the buffer
-            b.off()
-        };
-
-        if offset + len as u64 >= MAX_STREAM_SIZE {
-            return Err(Error::InvalidFrame);
-        }
-
-        let fin = first & 0x01 != 0;
-        b.rewind(len)?;
-        // This avoids cloning the buffer, as does the RangeBuf.
+        // This avoids cloning the buffer, as does the RangeBuf;
+        // we can do this because we decrypt into the application's buffer,
+        // overriding the previous packet's control since they're put at the trail. We
+        // are not outliving the caller.
+        b.skip(len)?;
         let metadata = stream::RecvBufInfo::from(offset, len, fin);
 
         Ok(Frame::StreamV3 {
@@ -1854,27 +1424,10 @@ fn parse_stream_frame(
             metadata,
         })
     } else {
-        let stream_id = b.get_varint()?;
-
-        let offset = if first & 0x04 != 0 {
-            b.get_varint()?
-        } else {
-            0
-        };
-
-        let len = if first & 0x02 != 0 {
-            b.get_varint()? as usize
-        } else {
-            b.cap()
-        };
-
-        if offset + len as u64 >= MAX_STREAM_SIZE {
-            return Err(Error::InvalidFrame);
-        }
-
-        let fin = first & 0x01 != 0;
-
         let data = b.get_bytes(len)?;
+        // QUIC v1 code is cloning the data wihin RangeBuf ; This is necessary
+        // since otherwise a reference may outlive the data provided to quiceh; e.g., if
+        // the data lives on the application's stack frame.
         let data = <RangeBuf>::from(data.as_ref(), offset, fin);
 
         Ok(Frame::Stream { stream_id, data })
@@ -1882,20 +1435,11 @@ fn parse_stream_frame(
 }
 
 fn parse_datagram_frame(
-    ty: u64, b: &mut octets_rev::Octets, version: u32,
+    ty: u64, b: &mut impl octets_rev::OctetsRead,
 ) -> Result<Frame> {
     let first = ty as u8;
 
-    let data = if likely(version == crate::PROTOCOL_VERSION_VREVERSO) {
-        let len = if first & 0x01 != 0 {
-            b.get_varint_reverse()? as usize
-        } else {
-            // this is equal to b.off(), but having a "reversed" function
-            // should help for understanding the code.
-            b.cap_reverse()
-        };
-        b.get_bytes_reverse(len)?
-    } else {
+    let data = {
         let len = if first & 0x01 != 0 {
             b.get_varint()? as usize
         } else {
@@ -1904,14 +1448,16 @@ fn parse_datagram_frame(
         b.get_bytes(len)?
     };
 
+    // TODO implementing zero-copy for datagram as well.
     Ok(Frame::Datagram {
-        data: Vec::from(data.buf()),
+        data: Vec::from(data.as_ref()),
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::PROTOCOL_VERSION_VREVERSO;
 
     #[test]
     fn padding() {
@@ -1920,16 +1466,24 @@ mod tests {
         let frame = Frame::Padding { len: 128 };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 128);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
+
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -1939,10 +1493,13 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
+
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1950,10 +1507,13 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
+
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1961,10 +1521,12 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1981,7 +1543,7 @@ mod tests {
 
         let wire_len = {
             let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 1);

--- a/quiceh/src/frame.rs
+++ b/quiceh/src/frame.rs
@@ -1542,7 +1542,12 @@ mod tests {
         let frame = Frame::Ping { mtu_probe: None };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
             frame.to_bytes(&mut b).unwrap()
         };
 
@@ -1552,10 +1557,12 @@ mod tests {
             assert_eq!(&d[..wire_len], [0x01_u8]);
         }
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -1565,10 +1572,12 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1576,10 +1585,12 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1587,10 +1598,12 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1616,16 +1629,24 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 17);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
+
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -1635,10 +1656,12 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1646,10 +1669,12 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1657,10 +1682,13 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
+
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1692,16 +1720,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 23);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -1711,10 +1746,12 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1722,10 +1759,12 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1733,10 +1772,12 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1756,8 +1797,13 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 13);
@@ -1775,10 +1821,12 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1786,10 +1834,12 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1797,10 +1847,12 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1819,16 +1871,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 7);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -1838,10 +1897,12 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1849,10 +1910,12 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1860,10 +1923,12 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1883,16 +1948,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 19);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -1902,10 +1974,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1913,10 +1982,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1924,10 +1990,12 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1945,16 +2013,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 17);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -1964,10 +2039,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1986,10 +2058,12 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,

--- a/quiceh/src/frame.rs
+++ b/quiceh/src/frame.rs
@@ -1493,13 +1493,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
-
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1507,13 +1501,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
-
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1521,12 +1509,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1572,12 +1555,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1585,12 +1563,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1598,12 +1571,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1656,12 +1624,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1669,12 +1632,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1682,13 +1640,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
-
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1746,12 +1698,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1759,12 +1706,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1772,12 +1714,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1808,10 +1745,12 @@ mod tests {
 
         assert_eq!(wire_len, 13);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -1821,12 +1760,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1834,12 +1768,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1847,12 +1776,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1897,12 +1821,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -1910,12 +1829,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -1923,12 +1837,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -1990,12 +1899,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2047,10 +1951,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2058,12 +1959,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
-            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-                Box::new(octets_rev::OctetsRev::with_slice(&d))
-            } else {
-                Box::new(octets_rev::Octets::with_slice(&d))
-            };
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2088,15 +1984,24 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 20);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
             assert_eq!(
                 Frame::from_bytes(
                     &mut b,
@@ -2116,10 +2021,7 @@ mod tests {
             );
         }
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2127,10 +2029,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2138,10 +2037,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2162,16 +2058,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 24);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2189,16 +2092,23 @@ mod tests {
         let frame = Frame::MaxData { max: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2208,10 +2118,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2219,10 +2126,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2230,10 +2134,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2252,16 +2153,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 7);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2271,10 +2179,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2282,10 +2187,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2293,10 +2195,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2312,15 +2211,22 @@ mod tests {
         let frame = Frame::MaxStreamsBidi { max: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
         assert_eq!(wire_len, 5);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2330,10 +2236,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2341,10 +2244,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2352,10 +2252,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2371,16 +2268,23 @@ mod tests {
         let frame = Frame::MaxStreamsUni { max: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2390,10 +2294,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2401,10 +2302,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2412,10 +2310,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2431,16 +2326,23 @@ mod tests {
         let frame = Frame::DataBlocked { limit: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2450,10 +2352,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2461,10 +2360,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2472,10 +2368,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2494,16 +2387,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 7);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2513,10 +2413,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2524,10 +2421,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2535,10 +2429,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2554,16 +2445,23 @@ mod tests {
         let frame = Frame::StreamsBlockedBidi { limit: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2573,10 +2471,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2584,10 +2479,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2595,10 +2487,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2614,16 +2503,23 @@ mod tests {
         let frame = Frame::StreamsBlockedUni { limit: 128_318_273 };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2633,10 +2529,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2644,10 +2537,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2655,10 +2545,46 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
+        assert!(Frame::from_bytes(
+            &mut b,
+            packet::Type::Handshake,
+            crate::PROTOCOL_VERSION
+        )
+        .is_err());
+
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
+        assert!(Frame::from_bytes(
+            &mut b,
+            packet::Type::ZeroRTT,
+            crate::PROTOCOL_VERSION
+        )
+        .is_ok());
+
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
+        assert!(Frame::from_bytes(
+            &mut b,
+            packet::Type::Initial,
+            crate::PROTOCOL_VERSION
+        )
+        .is_err());
+
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2679,16 +2605,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 41);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2698,10 +2631,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2709,10 +2639,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2720,10 +2647,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2739,16 +2663,23 @@ mod tests {
         let frame = Frame::RetireConnectionId { seq_num: 123_213 };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 5);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2758,10 +2689,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2769,10 +2697,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2780,10 +2705,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2801,16 +2723,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 9);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2820,10 +2749,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2831,10 +2757,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2842,10 +2765,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2863,16 +2783,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 9);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2882,10 +2809,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2893,10 +2817,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2904,10 +2825,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2927,16 +2845,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 22);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -2946,10 +2871,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -2957,10 +2879,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -2968,10 +2887,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -2990,17 +2906,23 @@ mod tests {
         };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 18);
-        let mut b = octets_rev::Octets::with_slice(&d);
 
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
-
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -3010,10 +2932,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -3021,10 +2940,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -3032,10 +2948,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -3051,17 +2964,23 @@ mod tests {
         let frame = Frame::HandshakeDone;
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 1);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
-
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -3071,10 +2990,7 @@ mod tests {
             Ok(frame)
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -3082,10 +2998,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -3093,10 +3006,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,
@@ -3114,16 +3024,23 @@ mod tests {
         let frame = Frame::Datagram { data: data.clone() };
 
         let wire_len = {
-            let mut b = octets_rev::OctetsMut::with_slice(&mut d);
-            frame.to_bytes(&mut b, crate::PROTOCOL_VERSION).unwrap()
+            let mut b: Box<dyn octets_rev::OctetsWrite> =
+                if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+                    Box::new(octets_rev::OctetsMutRev::with_slice(&mut d))
+                } else {
+                    Box::new(octets_rev::OctetsMut::with_slice(&mut d))
+                };
+            frame.to_bytes(&mut b).unwrap()
         };
 
         assert_eq!(wire_len, 15);
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        let mut b: Box<dyn octets_rev::OctetsRead<Bytes = octets_rev::Octets>> =
+            if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+                Box::new(octets_rev::OctetsRev::with_slice(&d))
+            } else {
+                Box::new(octets_rev::Octets::with_slice(&d))
+            };
         assert_eq!(
             Frame::from_bytes(
                 &mut b,
@@ -3133,10 +3050,7 @@ mod tests {
             Ok(frame.clone())
         );
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Initial,
@@ -3144,10 +3058,7 @@ mod tests {
         )
         .is_err());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::ZeroRTT,
@@ -3155,10 +3066,7 @@ mod tests {
         )
         .is_ok());
 
-        let mut b = octets_rev::Octets::with_slice(&d);
-        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
-            b.skip(wire_len).expect("skip issue");
-        }
+        b.rewind(wire_len).unwrap();
         assert!(Frame::from_bytes(
             &mut b,
             packet::Type::Handshake,

--- a/quiceh/src/frame.rs
+++ b/quiceh/src/frame.rs
@@ -1278,8 +1278,8 @@ impl std::fmt::Debug for Frame {
     }
 }
 
-fn parse_ack_frame(
-    ty: u64, b: &mut impl octets_rev::OctetsRead,
+fn parse_ack_frame<T: octets_rev::OctetsRead>(
+    ty: u64, b: &mut T,
 ) -> Result<Frame> {
     let first = ty as u8;
     let mut ranges = ranges::RangeSet::default();
@@ -1371,8 +1371,8 @@ pub fn encode_stream_header<T: octets_rev::OctetsWrite>(
     Ok(())
 }
 
-pub fn encode_dgram_header(
-    length: u64, b: &mut impl octets_rev::OctetsWrite,
+pub fn encode_dgram_header<T: octets_rev::OctetsWrite>(
+    length: u64, b: &mut T,
 ) -> Result<()> {
     let mut ty: u8 = 0x30;
 
@@ -1387,8 +1387,8 @@ pub fn encode_dgram_header(
     Ok(())
 }
 
-fn parse_stream_frame(
-    ty: u64, b: &mut impl octets_rev::OctetsRead, version: u32,
+fn parse_stream_frame<T: octets_rev::OctetsRead>(
+    ty: u64, b: &mut T, version: u32,
 ) -> Result<Frame> {
     let first = ty as u8;
 
@@ -1434,8 +1434,8 @@ fn parse_stream_frame(
     }
 }
 
-fn parse_datagram_frame(
-    ty: u64, b: &mut impl octets_rev::OctetsRead,
+fn parse_datagram_frame<T: octets_rev::OctetsRead>(
+    ty: u64, b: &mut T,
 ) -> Result<Frame> {
     let first = ty as u8;
 

--- a/quiceh/src/lib.rs
+++ b/quiceh/src/lib.rs
@@ -11731,7 +11731,7 @@ mod tests {
     }
 
     #[test]
-    fn streamv3_partial_consume() {
+    fn stream_vreverso_partial_consume() {
         if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
             let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
             config
@@ -11787,7 +11787,7 @@ mod tests {
     }
 
     #[test]
-    fn streamv3_not_in_order() {
+    fn stream_vreverso_not_in_order() {
         // Test whether unordered packets containing a Stream frame behave as
         // expected. i.e., the first received packet is not in order; its
         // data is copied internally into the library since the decryption
@@ -11850,7 +11850,7 @@ mod tests {
     }
 
     #[test]
-    fn streamv3_large_chunks_send_recv_with_hidden_send_copy() {
+    fn stream_vreverso_large_chunks_send_recv_with_hidden_send_copy() {
         if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
             let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
             config
@@ -11899,7 +11899,7 @@ mod tests {
     }
 
     #[test]
-    fn streamv3_send_recv_various_chunklen() {
+    fn stream_vreverso_send_recv_various_chunklen() {
         if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
             let mut buf = [0; 65535];
             let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();

--- a/quiceh/src/lib.rs
+++ b/quiceh/src/lib.rs
@@ -5093,7 +5093,7 @@ impl<F: BufFactory> Connection<F> {
                             b = OctetsMut::from(rev_b);
 
                             // back to the initial index.
-                            b.rewind(len + hdr_len)?;
+                            b.rewind(len)?;
 
                             (len, fin)
                         } else {
@@ -5259,7 +5259,7 @@ impl<F: BufFactory> Connection<F> {
                         b = OctetsMut::from(rev_b);
 
                         // back to the initial index.
-                        b.rewind(len + hdr_len + cumul)?;
+                        b.rewind(len + cumul)?;
                         len
                     } else {
                         let (mut crypto_hdr, mut crypto_payload) =

--- a/quiceh/src/lib.rs
+++ b/quiceh/src/lib.rs
@@ -1894,25 +1894,13 @@ macro_rules! push_frames_to_pkt {
                  **/
                 frame::Frame::StreamHeader { stream_id, offset, length, fin } => {
                     if $usehiddencopy {
-                        if $ver == crate::PROTOCOL_VERSION_VREVERSO {
-                            // not in place VReverso
-                            frame::encode_stream_footer(
-                                *stream_id,
-                                *offset,
-                                *length as u64,
-                                *fin,
-                                &mut $out,
-                            )?;
-                        } else {
-                            // not in place QUIC v1
-                            frame::encode_stream_header(
-                                *stream_id,
-                                *offset,
-                                *length as u64,
-                                *fin,
-                                &mut $out,
-                            )?;
-                        }
+                        frame::encode_stream_header(
+                            *stream_id,
+                            *offset,
+                            *length as u64,
+                            *fin,
+                            &mut $out,
+                        )?;
                     } else {
                         let hdr_len = 1 + // frame type
                             octets_rev::varint_len(*stream_id) + // stream_id
@@ -1926,24 +1914,13 @@ macro_rules! push_frames_to_pkt {
                 },
                 frame::Frame::CryptoVec { offset, length, rbvec } => {
                     if rbvec.len() > 0 {
-                        if $ver == crate::PROTOCOL_VERSION_VREVERSO {
-                            for rb in rbvec {
-                                $out.put_bytes(&rb[..])?;
-                            }
-                            frame::encode_crypto_footer(
-                                *offset,
-                                *length as u64,
-                                &mut $out
-                            )?;
-                        } else {
-                            frame::encode_crypto_header(
-                                *offset,
-                                *length as u64,
-                                &mut $out
-                            )?;
-                            for rb in rbvec {
-                                $out.put_bytes(&rb[..])?;
-                            }
+                        frame::encode_crypto_header(
+                            *offset,
+                            *length as u64,
+                            &mut $out
+                        )?;
+                        for rb in rbvec {
+                            $out.put_bytes(&rb[..])?;
                         }
                     }
                 }
@@ -1959,7 +1936,7 @@ macro_rules! push_frames_to_pkt {
                     $out.skip(length + hdr_len)?;
                 }
                 _ => {
-                    frame.to_bytes(&mut $out,  $ver)?;
+                    frame.to_bytes(&mut $out)?;
                 },
             }
         }
@@ -3395,8 +3372,9 @@ impl<F: BufFactory> Connection<F> {
             //set the offset at the end
             let payload_start_offset = payload.off();
             payload.skip(payload_len)?;
+            let mut payload: OctetsRev = payload.into();
             // start reverse buffer processing
-            while payload.off() > payload_start_offset {
+            while payload.cap() > 0 {
                 let frame =
                     frame::Frame::from_bytes(&mut payload, hdr.ty, self.version)?;
                 qlog_with_type!(QLOG_PACKET_RX, self.qlog, _q, {
@@ -5102,12 +5080,17 @@ impl<F: BufFactory> Connection<F> {
                             let (len, fin) =
                                 stream.send.emit(&mut b.as_mut()[..max_len])?;
                             // Advance the buffer
-                            b.skip(len)?;
+                            b.skip(len + hdr_len)?;
+
+                            let mut rev_b = OctetsMutRev::from(b);
 
                             // Encode the header reversed
-                            frame::encode_stream_footer(
-                                stream_id, stream_off, len as u64, fin, &mut b,
+                            frame::encode_stream_header(
+                                stream_id, stream_off, len as u64, fin,
+                                &mut rev_b,
                             )?;
+
+                            b = OctetsMut::from(rev_b);
 
                             // back to the initial index.
                             b.rewind(len + hdr_len)?;
@@ -5265,11 +5248,16 @@ impl<F: BufFactory> Connection<F> {
                             .send
                             .emit(&mut b.as_mut()[..max_len])?;
                         // this advances b to the Crypto Hdr expected location.
-                        b.skip(len)?;
+                        b.skip(len + hdr_len)?;
+
+                        let mut rev_b = OctetsMutRev::from(b);
                         // Encode the header reversed
-                        frame::encode_crypto_footer(
-                            crypto_off, len as u64, &mut b,
+                        frame::encode_crypto_header(
+                            crypto_off, len as u64, &mut rev_b,
                         )?;
+
+                        b = OctetsMut::from(rev_b);
+
                         // back to the initial index.
                         b.rewind(len + hdr_len + cumul)?;
                         len
@@ -5450,10 +5438,12 @@ impl<F: BufFactory> Connection<F> {
             };
             // let mut ctrl = vec![0; cumul-stream_len];
             // let mut b_ctrl = octets_rev::OctetsMut::with_slice(&mut ctrl);
-            push_frames_to_pkt!(b_ctrl, frames, true, self.version);
-            let b_ctrl_len = b_ctrl.off();
-            b_ctrl.rewind(b_ctrl_len)?;
-            (b_start, Some(b_ctrl), stream_len, b_ctrl_len)
+            b_ctrl.skip(cumul)?;
+            let mut b_ctrl_rev = OctetsMutRev::from(b_ctrl);
+            frames.reverse();
+            push_frames_to_pkt!(b_ctrl_rev, frames, true, self.version);
+            let b_ctrl = OctetsMut::from(b_ctrl_rev);
+            (b_start, Some(b_ctrl), stream_len, cumul)
         } else {
             push_frames_to_pkt!(b, frames, false, self.version);
             let b_len = b.off() - payload_offset;
@@ -8371,10 +8361,9 @@ impl<F: BufFactory> Connection<F> {
     }
 
     /// Processes an incoming frame.
-    fn process_frame(
-        &mut self, frame: frame::Frame, hdr: &packet::Header,
-        b: &mut octets_rev::Octets, recv_path_id: usize, epoch: packet::Epoch,
-        now: time::Instant,
+    fn process_frame<T: octets_rev::OctetsRead>(
+        &mut self, frame: frame::Frame, hdr: &packet::Header, b: &mut T,
+        recv_path_id: usize, epoch: packet::Epoch, now: time::Instant,
     ) -> Result<()> {
         trace!("{} rx frm {:?}", self.trace_id, frame);
 
@@ -10515,8 +10504,17 @@ pub mod testing {
         };
 
         let payload_offset = b.off();
-        for frame in frames {
-            frame.to_bytes(&mut b, conn.version)?;
+        if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
+            b.skip(payload_len)?;
+            let mut b_rev = OctetsMutRev::from(b);
+            for frame in frames {
+                frame.to_bytes(&mut b_rev)?;
+            }
+            b = OctetsMut::from(b_rev);
+        } else {
+            for frame in frames {
+                frame.to_bytes(&mut b)?;
+            }
         }
 
         let aead = match space.crypto_seal {
@@ -21152,6 +21150,9 @@ pub use crate::range_buf::BufSplit;
 pub use crate::stream::Chunk;
 
 use crate::stream::Stream;
+use octets_rev::OctetsMut;
+use octets_rev::OctetsMutRev;
+use octets_rev::OctetsRev;
 
 pub mod bufpool;
 mod cid;

--- a/quiceh/src/lib.rs
+++ b/quiceh/src/lib.rs
@@ -1885,7 +1885,7 @@ pub fn version_is_supported(version: u32) -> bool {
 /// Frames such as Stream, Crypto, etc. have already been written into the
 /// buffer at their intended position.
 macro_rules! push_frames_to_pkt {
-    ($out:expr, $frames:expr, $usehiddencopy:expr, $ver:expr) => {{
+    ($out:expr, $frames:expr, $usehiddencopy:expr, $ver:expr, $is_rev:expr) => {{
         for frame in $frames.iter() {
             match frame {
                 /*
@@ -1919,8 +1919,14 @@ macro_rules! push_frames_to_pkt {
                             *length as u64,
                             &mut $out
                         )?;
-                        for rb in rbvec {
-                            $out.put_bytes(&rb[..])?;
+                        if $is_rev {
+                            for rb in rbvec.iter().rev() {
+                                $out.put_bytes(&rb[..])?;
+                            }
+                        } else {
+                            for rb in rbvec {
+                                $out.put_bytes(&rb[..])?;
+                            }
                         }
                     }
                 }
@@ -5441,7 +5447,7 @@ impl<F: BufFactory> Connection<F> {
                 );
                 b_ctrl.skip(cumul - stream_len)?;
                 let mut b_ctrl_rev = OctetsMutRev::from(b_ctrl);
-                push_frames_to_pkt!(b_ctrl_rev, frames, true, self.version);
+                push_frames_to_pkt!(b_ctrl_rev, frames, true, self.version, true);
                 b_ctrl = OctetsMut::from(b_ctrl_rev);
                 trace!("b_ctrl off at {}", b_ctrl.off());
                 (b, Some(b_ctrl), stream_len, cumul - stream_len)
@@ -5472,7 +5478,7 @@ impl<F: BufFactory> Connection<F> {
                     0_usize
                 };
 
-                push_frames_to_pkt!(b_ctrl, frames, true, self.version);
+                push_frames_to_pkt!(b_ctrl, frames, true, self.version, false);
                 let b_ctrl_len = b_ctrl.off();
                 b_ctrl.rewind(b_ctrl_len)?;
                 (b, Some(b_ctrl), stream_len, b_ctrl_len)
@@ -5482,11 +5488,11 @@ impl<F: BufFactory> Connection<F> {
                 b.skip(cumul)?;
                 let mut b_rev = OctetsMutRev::from(b);
                 frames.reverse();
-                push_frames_to_pkt!(b_rev, frames, false, self.version);
+                push_frames_to_pkt!(b_rev, frames, false, self.version, true);
                 b = OctetsMut::from(b_rev);
                 (b, None, cumul, 0_usize)
             } else {
-                push_frames_to_pkt!(b, frames, false, self.version);
+                push_frames_to_pkt!(b, frames, false, self.version, false);
                 let b_len = b.off() - payload_offset;
                 (b, None, b_len, 0_usize)
             }

--- a/quiceh/src/lib.rs
+++ b/quiceh/src/lib.rs
@@ -3374,7 +3374,7 @@ impl<F: BufFactory> Connection<F> {
             payload.skip(payload_len)?;
             let mut payload: OctetsRev = payload.into();
             // start reverse buffer processing
-            while payload.cap() > 0 {
+            while payload.cap() > payload_start_offset {
                 let frame =
                     frame::Frame::from_bytes(&mut payload, hdr.ty, self.version)?;
                 qlog_with_type!(QLOG_PACKET_RX, self.qlog, _q, {
@@ -5392,9 +5392,7 @@ impl<F: BufFactory> Connection<F> {
             .use_hidden_crypt_copy_for_zc
         {
             // If we're in VReverso, the frame should be first.
-            let (b_start, mut b_ctrl, stream_len) = if self.version
-                == crate::PROTOCOL_VERSION_VREVERSO
-            {
+            if self.version == crate::PROTOCOL_VERSION_VREVERSO {
                 let stream_len =
                     if let Some(frame::Frame::StreamHeader { length, .. }) =
                         frames.first()
@@ -5403,17 +5401,24 @@ impl<F: BufFactory> Connection<F> {
                     } else {
                         0_usize
                     };
+
+                frames.reverse();
                 // ctrl cleartext is written inside the destination buffer,
                 // aligned on a multiple of the AES blocksize.
+
                 let align = stream_len % 16;
-                let (b, b_ctrl) =
+                let (b, mut b_ctrl) =
                     b.split_at(payload_offset + stream_len + align)?;
-                (b, b_ctrl, stream_len)
+                b_ctrl.skip(cumul - stream_len)?;
+                let mut b_ctrl_rev = OctetsMutRev::from(b_ctrl);
+                push_frames_to_pkt!(b_ctrl_rev, frames, true, self.version);
+                b_ctrl = OctetsMut::from(b_ctrl_rev);
+                (b, Some(b_ctrl), stream_len, cumul - stream_len)
             } else {
                 // In V1 we would start with the ctrl.
-                let (b, b_ctrl) = b.split_at(payload_offset)?;
+                let (b, mut b_ctrl) = b.split_at(payload_offset)?;
                 // The StreamHeader frame should be last.
-                if let Some(frame) = maybe_stream_header {
+                let stream_len = if let Some(frame) = &maybe_stream_header {
                     let frame_len = frame.wire_len();
                     //cumul -= frame_len;
                     left += frame_len;
@@ -5421,33 +5426,44 @@ impl<F: BufFactory> Connection<F> {
                         length, ..
                     } = frame
                     {
-                        length
+                        *length
                     } else {
                         0_usize
                     };
 
                     #[allow(unused_assignments)]
-                    if push_frame_to_vec!(frames, frame, left, cumul) {
-                        (b, b_ctrl, len)
+                    if push_frame_to_vec!(frames, frame.clone(), left, cumul) {
+                        len
                     } else {
-                        (b, b_ctrl, 0_usize)
+                        0_usize
                     }
                 } else {
-                    (b, b_ctrl, 0_usize)
-                }
-            };
-            // let mut ctrl = vec![0; cumul-stream_len];
-            // let mut b_ctrl = octets_rev::OctetsMut::with_slice(&mut ctrl);
-            b_ctrl.skip(cumul)?;
-            let mut b_ctrl_rev = OctetsMutRev::from(b_ctrl);
-            frames.reverse();
-            push_frames_to_pkt!(b_ctrl_rev, frames, true, self.version);
-            let b_ctrl = OctetsMut::from(b_ctrl_rev);
-            (b_start, Some(b_ctrl), stream_len, cumul)
+                    0_usize
+                };
+
+                push_frames_to_pkt!(b_ctrl, frames, true, self.version);
+                let b_ctrl_len = b_ctrl.off();
+                b_ctrl.rewind(b_ctrl_len)?;
+                (b, Some(b_ctrl), stream_len, b_ctrl_len)
+            }
         } else {
-            push_frames_to_pkt!(b, frames, false, self.version);
-            let b_len = b.off() - payload_offset;
-            (b, None, b_len, 0_usize)
+            if self.version == crate::PROTOCOL_VERSION_VREVERSO {
+                let stream_frame_len = if let Some(frame) = &maybe_stream_header {
+                    frame.wire_len()
+                } else {
+                    0_usize
+                };
+                b.skip(stream_frame_len + cumul)?;
+                let mut b_rev = OctetsMutRev::from(b);
+                frames.reverse();
+                push_frames_to_pkt!(b_rev, frames, false, self.version);
+                b = OctetsMut::from(b_rev);
+                (b, None, stream_frame_len + cumul, 0_usize)
+            } else {
+                push_frames_to_pkt!(b, frames, false, self.version);
+                let b_len = b.off() - payload_offset;
+                (b, None, b_len, 0_usize)
+            }
         };
 
         let payload_len = b_len + b_ctrl_len;
@@ -5537,7 +5553,7 @@ impl<F: BufFactory> Connection<F> {
         let written = if self.use_hidden_crypt_copy_for_zc {
             let sentry = if likely(self.version == PROTOCOL_VERSION_VREVERSO) {
                 if let Some(frame::Frame::StreamHeader { stream_id, .. }) =
-                    frames.first()
+                    &maybe_stream_header
                 {
                     Some(self.streams.entry(*stream_id))
                 } else {
@@ -8635,7 +8651,11 @@ impl<F: BufFactory> Connection<F> {
                 // best.
                 //
                 if stream.recv.not_in_order(&metadata) {
-                    let data = b.peek_bytes(metadata.len())?;
+                    // We should be at the payload_offset; we can shift the buffer
+                    // to the right and then call get_bytes; or alternatively directly
+                    // read metadata.len() at b's offset.
+                    b.rewind(metadata.len())?;
+                    let data = b.get_bytes(metadata.len())?;
                     // This sucks since it copies; and should be avoided at all
                     // ("let's keep it flexible") cost. (see
                     // comments above).
@@ -10507,10 +10527,11 @@ pub mod testing {
         if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
             b.skip(payload_len)?;
             let mut b_rev = OctetsMutRev::from(b);
-            for frame in frames {
+            for frame in frames.iter().rev() {
                 frame.to_bytes(&mut b_rev)?;
             }
             b = OctetsMut::from(b_rev);
+            b.skip(payload_len)?;
         } else {
             for frame in frames {
                 frame.to_bytes(&mut b)?;
@@ -11783,7 +11804,7 @@ mod tests {
     }
 
     #[test]
-    fn streamv3_large_chunks_send_recv() {
+    fn streamv3_large_chunks_send_recv_with_hidden_send_copy() {
         if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
             let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
             config
@@ -11809,6 +11830,8 @@ mod tests {
             let sendbuf = [0; 12000];
 
             let mut pipe = <Pipe>::with_config(&mut config).unwrap();
+
+            env_logger::builder().format_timestamp_nanos().init();
             assert_eq!(pipe.handshake(), Ok(()));
 
             for _ in 1..10 {
@@ -21094,14 +21117,12 @@ mod tests {
         ];
 
         let pkt_type = packet::Type::Short;
-        if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_V1 {
-            pipe.send_pkt_to_server(pkt_type, &frames, &mut buf)
-                .unwrap();
-        } else {
+        if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {
+            // The order above assumes they'd be read from top to bottom.
             frames.reverse();
-            pipe.send_pkt_to_server(pkt_type, &frames, &mut buf)
-                .unwrap();
         }
+        pipe.send_pkt_to_server(pkt_type, &frames, &mut buf)
+            .unwrap();
 
         let (s1, s2, s3, s4) =
             if crate::PROTOCOL_VERSION == crate::PROTOCOL_VERSION_VREVERSO {

--- a/quiceh/src/lib.rs
+++ b/quiceh/src/lib.rs
@@ -5150,6 +5150,7 @@ impl<F: BufFactory> Connection<F> {
                     let wire_len = frame.wire_len();
                     left -= wire_len;
                     // XXX we should refactor to avoid this.
+                    maybe_frame = frame.clone();
                     frames.insert(0, frame);
                     ack_eliciting = true;
                     in_flight = true;
@@ -5241,8 +5242,15 @@ impl<F: BufFactory> Connection<F> {
                 } else {
                     let len = if likely(self.version == PROTOCOL_VERSION_VREVERSO)
                     {
-                        //located potentally after other control frames
-                        b.skip(cumul)?;
+                        //located potentally after the stream frame
+                        let skip_len = if let Some(frame) = &maybe_stream_header {
+                            let skip_len = frame.wire_len();
+                            skip_len
+                        } else {
+                            0
+                        };
+
+                        b.skip(skip_len)?;
                         let (len, _) = pkt_space
                             .crypto_stream
                             .send
@@ -5259,7 +5267,7 @@ impl<F: BufFactory> Connection<F> {
                         b = OctetsMut::from(rev_b);
 
                         // back to the initial index.
-                        b.rewind(len + cumul)?;
+                        b.rewind(len + skip_len)?;
                         len
                     } else {
                         let (mut crypto_hdr, mut crypto_payload) =
@@ -5293,10 +5301,26 @@ impl<F: BufFactory> Connection<F> {
                     }
                 };
 
-                if push_frame_to_vec!(frames, frame, left, cumul) {
+                if !self.use_hidden_crypt_copy_for_zc
+                    && self.version == crate::PROTOCOL_VERSION_VREVERSO
+                {
+                    let wire_len = frame.wire_len();
+                    if maybe_stream_header.is_some() {
+                        frames.insert(1, frame);
+                    } else {
+                        frames.insert(0, frame);
+                    }
+                    left -= wire_len;
+                    cumul += wire_len;
                     ack_eliciting = true;
                     in_flight = true;
                     has_data = true;
+                } else {
+                    if push_frame_to_vec!(frames, frame, left, cumul) {
+                        ack_eliciting = true;
+                        in_flight = true;
+                        has_data = true;
+                    }
                 }
             }
         }
@@ -5448,17 +5472,12 @@ impl<F: BufFactory> Connection<F> {
             }
         } else {
             if self.version == crate::PROTOCOL_VERSION_VREVERSO {
-                let stream_frame_len = if let Some(frame) = &maybe_stream_header {
-                    frame.wire_len()
-                } else {
-                    0_usize
-                };
-                b.skip(stream_frame_len + cumul)?;
+                b.skip(cumul)?;
                 let mut b_rev = OctetsMutRev::from(b);
                 frames.reverse();
                 push_frames_to_pkt!(b_rev, frames, false, self.version);
                 b = OctetsMut::from(b_rev);
-                (b, None, stream_frame_len + cumul, 0_usize)
+                (b, None, cumul, 0_usize)
             } else {
                 push_frames_to_pkt!(b, frames, false, self.version);
                 let b_len = b.off() - payload_offset;
@@ -5551,21 +5570,25 @@ impl<F: BufFactory> Connection<F> {
         };
 
         let written = if self.use_hidden_crypt_copy_for_zc {
-            let sentry = if likely(self.version == PROTOCOL_VERSION_VREVERSO) {
+            // For vreverso, we called reverse(); so it should be the
+            // last.
+            let sentry =
                 if let Some(frame::Frame::StreamHeader { stream_id, .. }) =
-                    &maybe_stream_header
+                    frames.last()
                 {
                     Some(self.streams.entry(*stream_id))
+                } else if self.version == crate::PROTOCOL_VERSION_V1 {
+                    if let Some(frame::Frame::StreamHeader {
+                        stream_id, ..
+                    }) = &maybe_stream_header
+                    {
+                        Some(self.streams.entry(*stream_id))
+                    } else {
+                        None
+                    }
                 } else {
                     None
-                }
-            } else if let Some(frame::Frame::StreamHeader { stream_id, .. }) =
-                frames.last()
-            {
-                Some(self.streams.entry(*stream_id))
-            } else {
-                None
-            };
+                };
 
             let written = if likely(self.version == PROTOCOL_VERSION_VREVERSO) {
                 // We encrypt with the data in inbuf and the ctrl data in extra_in, starting
@@ -8562,9 +8585,16 @@ impl<F: BufFactory> Connection<F> {
 
                 while let Ok((read, _)) = stream.recv.emit(&mut crypto_buf) {
                     let recv_buf = &crypto_buf[..read];
+                    trace!(
+                        "{} providing {} bytes of crypto data at lvl {:?}",
+                        self.trace_id,
+                        read,
+                        level
+                    );
                     self.handshake.provide_data(level, recv_buf)?;
                 }
 
+                trace!("{} calling do_handshake", self.trace_id);
                 self.do_handshake(now)?;
             },
 
@@ -16767,6 +16797,7 @@ mod tests {
         let mut b = [0; 15];
         if crate::PROTOCOL_VERSION == PROTOCOL_VERSION_VREVERSO {
             pipe.server.stream_peek(stream_id).unwrap();
+            pipe.server.stream_consumed(stream_id, 1).unwrap();
         } else {
             pipe.server.stream_recv(stream_id, &mut b).unwrap();
         }

--- a/quiceh/src/lib.rs
+++ b/quiceh/src/lib.rs
@@ -2025,6 +2025,12 @@ impl Default for QlogInfo {
     }
 }
 
+struct ChunkMetaData {
+    stream_id: u64,
+    start_off: u64,
+    len: usize,
+}
+
 impl<F: BufFactory> Connection<F> {
     fn new(
         scid: &ConnectionId, odcid: Option<&ConnectionId>, local: SocketAddr,
@@ -3357,7 +3363,7 @@ impl<F: BufFactory> Connection<F> {
 
         // Process packet payload. If a frame cannot be processed, store the
         // error and stop further packet processing.
-        let mut frame_processing_err = None;
+        let frame_processing_err;
 
         // To know if the peer migrated the connection, we need to keep track
         // whether this is a non-probing packet.
@@ -3365,61 +3371,26 @@ impl<F: BufFactory> Connection<F> {
 
         // Process packet payload.
         if likely(self.version == PROTOCOL_VERSION_VREVERSO) {
-            struct ChunkMetaData {
-                stream_id: u64,
-                start_off: u64,
-                len: usize,
-            }
-            let mut smeta = ChunkMetaData {
-                stream_id: 0,
-                start_off: 0,
-                len: 0,
-            };
             //set the offset at the end
             let payload_start_offset = payload.off();
             payload.skip(payload_len)?;
             let mut payload: OctetsRev = payload.into();
+
             // start reverse buffer processing
-            while payload.cap() > payload_start_offset {
-                let frame =
-                    frame::Frame::from_bytes(&mut payload, hdr.ty, self.version)?;
-                qlog_with_type!(QLOG_PACKET_RX, self.qlog, _q, {
-                    qlog_frames.push(frame.to_qlog());
-                });
+            let (err, smeta) = self.process_payload_frames(
+                &mut payload,
+                payload_start_offset,
+                &hdr,
+                recv_pid,
+                epoch,
+                now,
+                &mut ack_elicited,
+                &mut probing,
+                #[cfg(feature = "qlog")]
+                &mut qlog_frames,
+            )?;
+            frame_processing_err = err;
 
-                if frame.ack_eliciting() {
-                    ack_elicited = true;
-                }
-
-                if !frame.probing() {
-                    probing = false;
-                }
-
-                if let frame::Frame::StreamV3 {
-                    stream_id: s,
-                    metadata: ref m,
-                } = frame
-                {
-                    // If this is the stream frame intented for zc.
-                    if payload.off() == payload_start_offset {
-                        smeta.stream_id = s;
-                        smeta.start_off = m.off();
-                        smeta.len = m.len();
-                    }
-                }
-
-                if let Err(e) = self.process_frame(
-                    frame,
-                    &hdr,
-                    &mut payload,
-                    recv_pid,
-                    epoch,
-                    now,
-                ) {
-                    frame_processing_err = Some(e);
-                    break;
-                }
-            }
             // Handle chunks and check wether we can advance contiguous data to avoid the next
             // packet to be believed not in order.
 
@@ -3466,34 +3437,19 @@ impl<F: BufFactory> Connection<F> {
                 }
             }
         } else {
-            while payload.cap() > 0 {
-                let frame =
-                    frame::Frame::from_bytes(&mut payload, hdr.ty, self.version)?;
-
-                qlog_with_type!(QLOG_PACKET_RX, self.qlog, _q, {
-                    qlog_frames.push(frame.to_qlog());
-                });
-
-                if frame.ack_eliciting() {
-                    ack_elicited = true;
-                }
-
-                if !frame.probing() {
-                    probing = false;
-                }
-
-                if let Err(e) = self.process_frame(
-                    frame,
-                    &hdr,
-                    &mut payload,
-                    recv_pid,
-                    epoch,
-                    now,
-                ) {
-                    frame_processing_err = Some(e);
-                    break;
-                }
-            }
+            let (err, _smeta) = self.process_payload_frames(
+                &mut payload,
+                0,
+                &hdr,
+                recv_pid,
+                epoch,
+                now,
+                &mut ack_elicited,
+                &mut probing,
+                #[cfg(feature = "qlog")]
+                &mut qlog_frames,
+            )?;
+            frame_processing_err = err;
         }
 
         qlog_with_type!(QLOG_PACKET_RX, self.qlog, q, {
@@ -9025,6 +8981,74 @@ impl<F: BufFactory> Connection<F> {
         }
 
         Ok(())
+    }
+
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn process_payload_frames<'a, T>(
+        &mut self, payload: &mut T, stop_off: usize, hdr: &packet::Header,
+        recv_pid: usize, epoch: packet::Epoch, now: time::Instant,
+        ack_elicited: &mut bool, probing: &mut bool,
+        #[cfg(feature = "qlog")] qlog_frames: &mut Vec<
+            qlog::events::quic::QuicFrame,
+        >,
+    ) -> Result<(Option<Error>, ChunkMetaData)>
+    where
+        T: octets_rev::OctetsRead<Bytes = octets_rev::Octets<'a>>,
+    {
+        let mut frame_processing_err = None;
+        let mut smeta = ChunkMetaData {
+            stream_id: 0,
+            start_off: 0,
+            len: 0,
+        };
+
+        while payload.cap() > stop_off {
+            let frame =
+                match frame::Frame::from_bytes(payload, hdr.ty, self.version) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        frame_processing_err = Some(e);
+                        break;
+                    },
+                };
+
+            qlog_with_type!(QLOG_PACKET_RX, self.qlog, _q, {
+                qlog_frames.push(frame.to_qlog());
+            });
+
+            if frame.ack_eliciting() {
+                *ack_elicited = true;
+            }
+
+            if !frame.probing() {
+                *probing = false;
+            }
+
+            if self.version == PROTOCOL_VERSION_VREVERSO {
+                if let frame::Frame::StreamV3 {
+                    stream_id: s,
+                    metadata: ref m,
+                } = frame
+                {
+                    // If this is the stream frame intented for zc.
+                    if payload.off() == stop_off {
+                        smeta.stream_id = s;
+                        smeta.start_off = m.off();
+                        smeta.len = m.len();
+                    }
+                }
+            }
+
+            if let Err(e) =
+                self.process_frame(frame, hdr, payload, recv_pid, epoch, now)
+            {
+                frame_processing_err = Some(e);
+                break;
+            }
+        }
+
+        Ok((frame_processing_err, smeta))
     }
 
     /// Drops the keys and recovery state for the given epoch.

--- a/quiceh/src/lib.rs
+++ b/quiceh/src/lib.rs
@@ -5427,16 +5427,23 @@ impl<F: BufFactory> Connection<F> {
                     };
 
                 frames.reverse();
+                trace!("frames {:?}", frames);
                 // ctrl cleartext is written inside the destination buffer,
                 // aligned on a multiple of the AES blocksize.
 
                 let align = stream_len % 16;
                 let (b, mut b_ctrl) =
                     b.split_at(payload_offset + stream_len + align)?;
+                trace!(
+                    "split_at: {}; skipping {} bytes",
+                    payload_offset + stream_len + align,
+                    cumul - stream_len
+                );
                 b_ctrl.skip(cumul - stream_len)?;
                 let mut b_ctrl_rev = OctetsMutRev::from(b_ctrl);
                 push_frames_to_pkt!(b_ctrl_rev, frames, true, self.version);
                 b_ctrl = OctetsMut::from(b_ctrl_rev);
+                trace!("b_ctrl off at {}", b_ctrl.off());
                 (b, Some(b_ctrl), stream_len, cumul - stream_len)
             } else {
                 // In V1 we would start with the ctrl.
@@ -8238,7 +8245,10 @@ impl<F: BufFactory> Connection<F> {
                 return Ok(());
             },
 
-            Err(e) => return Err(e),
+            Err(e) => {
+                trace!("do_handshake returned Error {:?}", e);
+                return Err(e);
+            },
         };
 
         self.handshake_completed = self.handshake.is_completed();
@@ -11855,6 +11865,7 @@ mod tests {
             config.set_initial_max_data(10 * 32 * 1024);
             config.enable_hidden_copy_for_zc_sender(true);
             config.set_expected_chunklen_to_consume(120_000);
+            config.verify_peer(false);
 
             let datasize = 12000;
             let sendbuf = [0; 12000];

--- a/quiceh/src/lib.rs
+++ b/quiceh/src/lib.rs
@@ -10726,9 +10726,9 @@ pub mod testing {
 
         let mut frames = Vec::new();
         if likely(conn.version == PROTOCOL_VERSION_VREVERSO) {
-            let payload_start_offset = payload.off();
             payload.skip(payload_len)?;
-            while payload.off() > payload_start_offset {
+            let mut payload: OctetsRev = payload.into();
+            while payload.cap() > 0 {
                 let frame =
                     frame::Frame::from_bytes(&mut payload, hdr.ty, conn.version)?;
                 frames.push(frame);
@@ -15146,7 +15146,7 @@ mod tests {
         let frames = [frame::Frame::Padding { len: 10 }];
 
         for frame in &frames {
-            frame.to_bytes(&mut b, pipe.client.version).unwrap();
+            frame.to_bytes(&mut b).unwrap();
         }
 
         let space = &mut pipe.client.pkt_num_spaces[epoch];
@@ -20888,9 +20888,7 @@ mod tests {
         let payload_offset = b.off();
 
         for frame in frames {
-            frame
-                .to_bytes(&mut b, pipe.client.version)
-                .expect("encode frames");
+            frame.to_bytes(&mut b).expect("encode frames");
         }
 
         let aead = space.crypto_seal.as_ref().expect("crypto seal");

--- a/quiceh/src/tls/mod.rs
+++ b/quiceh/src/tls/mod.rs
@@ -528,6 +528,7 @@ impl Handshake {
     pub fn do_handshake(&mut self, ex_data: &mut ExData) -> Result<()> {
         self.set_ex_data(*QUICHE_EX_DATA_INDEX, ex_data)?;
         let rc = unsafe { SSL_do_handshake(self.as_mut_ptr()) };
+        trace!("SSL_do_handshake returned {}", rc);
         self.set_ex_data::<Connection>(*QUICHE_EX_DATA_INDEX, std::ptr::null())?;
         self.set_transport_error(ex_data, rc);
         self.map_result_ssl(rc)

--- a/quiceh/src/tls/mod.rs
+++ b/quiceh/src/tls/mod.rs
@@ -528,7 +528,6 @@ impl Handshake {
     pub fn do_handshake(&mut self, ex_data: &mut ExData) -> Result<()> {
         self.set_ex_data(*QUICHE_EX_DATA_INDEX, ex_data)?;
         let rc = unsafe { SSL_do_handshake(self.as_mut_ptr()) };
-        trace!("SSL_do_handshake returned {}", rc);
         self.set_ex_data::<Connection>(*QUICHE_EX_DATA_INDEX, std::ptr::null())?;
         self.set_transport_error(ex_data, rc);
         self.map_result_ssl(rc)
@@ -1087,19 +1086,25 @@ unsafe fn SSL_CTX_free(ctx: *mut SSL_CTX) {
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_CTX_use_certificate_chain_file( ctx: *mut SSL_CTX, file: *const c_char, ) -> c_int {
+unsafe fn SSL_CTX_use_certificate_chain_file(
+    ctx: *mut SSL_CTX, file: *const c_char,
+) -> c_int {
     sys::SSL_CTX_use_certificate_chain_file(ctx as _, file as _) as _
 }
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_CTX_use_PrivateKey_file( ctx: *mut SSL_CTX, file: *const c_char, ty: c_int, ) -> c_int {
+unsafe fn SSL_CTX_use_PrivateKey_file(
+    ctx: *mut SSL_CTX, file: *const c_char, ty: c_int,
+) -> c_int {
     sys::SSL_CTX_use_PrivateKey_file(ctx as _, file as _, ty as _) as _
 }
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_CTX_load_verify_locations( ctx: *mut SSL_CTX, file: *const c_char, path: *const c_char, ) -> c_int {
+unsafe fn SSL_CTX_load_verify_locations(
+    ctx: *mut SSL_CTX, file: *const c_char, path: *const c_char,
+) -> c_int {
     sys::SSL_CTX_load_verify_locations(ctx as _, file as _, path as _) as _
 }
 
@@ -1119,31 +1124,59 @@ unsafe fn SSL_CTX_get_cert_store(ctx: *mut SSL_CTX) -> *mut X509_STORE {
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_CTX_set_verify( ctx: *mut SSL_CTX, mode: c_int, cb: Option< unsafe extern "C" fn( ok: c_int, store_ctx: *mut X509_STORE_CTX, ) -> c_int, >, ) {
+unsafe fn SSL_CTX_set_verify(
+    ctx: *mut SSL_CTX, mode: c_int,
+    cb: Option<
+        unsafe extern "C" fn(ok: c_int, store_ctx: *mut X509_STORE_CTX) -> c_int,
+    >,
+) {
     sys::SSL_CTX_set_verify(ctx as _, mode as _, std::mem::transmute(cb));
 }
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_CTX_set_keylog_callback( ctx: *mut SSL_CTX, cb: Option<unsafe extern "C" fn(ssl: *const SSL, line: *const c_char)>, ) {
+unsafe fn SSL_CTX_set_keylog_callback(
+    ctx: *mut SSL_CTX,
+    cb: Option<unsafe extern "C" fn(ssl: *const SSL, line: *const c_char)>,
+) {
     sys::SSL_CTX_set_keylog_callback(ctx as _, std::mem::transmute(cb));
 }
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_CTX_set_alpn_protos( ctx: *mut SSL_CTX, protos: *const u8, protos_len: usize, ) -> c_int {
+unsafe fn SSL_CTX_set_alpn_protos(
+    ctx: *mut SSL_CTX, protos: *const u8, protos_len: usize,
+) -> c_int {
     sys::SSL_CTX_set_alpn_protos(ctx as _, protos as _, protos_len as _) as _
 }
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_CTX_set_alpn_select_cb( ctx: *mut SSL_CTX, cb: Option< unsafe extern "C" fn( ssl: *mut SSL, out: *mut *const u8, out_len: *mut u8, inp: *mut u8, in_len: c_uint, arg: *mut c_void, ) -> c_int, >, arg: *mut c_void, ) {
+unsafe fn SSL_CTX_set_alpn_select_cb(
+    ctx: *mut SSL_CTX,
+    cb: Option<
+        unsafe extern "C" fn(
+            ssl: *mut SSL,
+            out: *mut *const u8,
+            out_len: *mut u8,
+            inp: *mut u8,
+            in_len: c_uint,
+            arg: *mut c_void,
+        ) -> c_int,
+    >,
+    arg: *mut c_void,
+) {
     sys::SSL_CTX_set_alpn_select_cb(ctx as _, std::mem::transmute(cb), arg as _);
 }
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_CTX_sess_set_new_cb( ctx: *mut SSL_CTX, cb: Option< unsafe extern "C" fn( ssl: *mut SSL, session: *mut SSL_SESSION, ) -> c_int, >, ) {
+unsafe fn SSL_CTX_sess_set_new_cb(
+    ctx: *mut SSL_CTX,
+    cb: Option<
+        unsafe extern "C" fn(ssl: *mut SSL, session: *mut SSL_SESSION) -> c_int,
+    >,
+) {
     sys::SSL_CTX_sess_set_new_cb(ctx as _, std::mem::transmute(cb));
 }
 
@@ -1215,13 +1248,18 @@ unsafe fn SSL_set_quiet_shutdown(ssl: *mut SSL, mode: c_int) {
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_set_quic_transport_params( ssl: *mut SSL, params: *const u8, params_len: usize, ) -> c_int {
-    sys::SSL_set_quic_transport_params(ssl as _, params as _, params_len as _) as _
+unsafe fn SSL_set_quic_transport_params(
+    ssl: *mut SSL, params: *const u8, params_len: usize,
+) -> c_int {
+    sys::SSL_set_quic_transport_params(ssl as _, params as _, params_len as _)
+        as _
 }
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_set_quic_method( ssl: *mut SSL, quic_method: *const SSL_QUIC_METHOD, ) -> c_int {
+unsafe fn SSL_set_quic_method(
+    ssl: *mut SSL, quic_method: *const SSL_QUIC_METHOD,
+) -> c_int {
     sys::SSL_set_quic_method(ssl as _, quic_method as _) as _
 }
 
@@ -1240,13 +1278,21 @@ unsafe fn SSL_set_options(ssl: *mut SSL, opts: u32) -> u32 {
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_get_peer_quic_transport_params( ssl: *const SSL, out_params: *mut *const u8, out_params_len: *mut usize, ) {
-    sys::SSL_get_peer_quic_transport_params(ssl as _, out_params as _, out_params_len as _);
+unsafe fn SSL_get_peer_quic_transport_params(
+    ssl: *const SSL, out_params: *mut *const u8, out_params_len: *mut usize,
+) {
+    sys::SSL_get_peer_quic_transport_params(
+        ssl as _,
+        out_params as _,
+        out_params_len as _,
+    );
 }
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_get0_alpn_selected( ssl: *const SSL, out: *mut *const u8, out_len: *mut u32, ) {
+unsafe fn SSL_get0_alpn_selected(
+    ssl: *const SSL, out: *mut *const u8, out_len: *mut u32,
+) {
     sys::SSL_get0_alpn_selected(ssl as _, out as _, out_len as _);
 }
 
@@ -1258,7 +1304,9 @@ unsafe fn SSL_get_servername(ssl: *const SSL, ty: c_int) -> *const c_char {
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn SSL_provide_quic_data( ssl: *mut SSL, level: crypto::Level, data: *const u8, len: usize, ) -> c_int {
+unsafe fn SSL_provide_quic_data(
+    ssl: *mut SSL, level: crypto::Level, data: *const u8, len: usize,
+) -> c_int {
     sys::SSL_provide_quic_data(ssl as _, level as _, data as _, len as _) as _
 }
 
@@ -1321,7 +1369,9 @@ unsafe fn SSL_SESSION_free(session: *mut SSL_SESSION) {
 // X509_VERIFY_PARAM
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn X509_VERIFY_PARAM_set1_host( param: *mut X509_VERIFY_PARAM, name: *const c_char, namelen: usize, ) -> c_int {
+unsafe fn X509_VERIFY_PARAM_set1_host(
+    param: *mut X509_VERIFY_PARAM, name: *const c_char, namelen: usize,
+) -> c_int {
     sys::X509_VERIFY_PARAM_set1_host(param as _, name as _, namelen as _) as _
 }
 
@@ -1344,7 +1394,9 @@ unsafe fn X509_free(x: *mut X509) {
 #[cfg(windows)]
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn d2i_X509(px: *mut X509, input: *const *const u8, len: c_int) -> *mut X509 {
+unsafe fn d2i_X509(
+    px: *mut X509, input: *const *const u8, len: c_int,
+) -> *mut X509 {
     sys::d2i_X509(px as _, input as _, len as _) as _
 }
 
@@ -1368,7 +1420,6 @@ unsafe fn ERR_error_string_n(err: c_uint, buf: *mut c_char, len: usize) {
 unsafe fn OPENSSL_free(ptr: *mut c_void) {
     sys::OPENSSL_free(ptr as _);
 }
-
 
 mod boringssl_or_aws;
 use boringssl_or_aws::*;


### PR DESCRIPTION
… new types OctetsRev, OctetsMutRev counterpart to Octets and OctetsMut. Remoing _reverse() suffix, and moving reverse logic into its own type

Todo:
 -  remove likely_stable dependency
 -  add missing documentation
 -  add an example
 -  prepare changes in quiceh to support impl &mut OctetsRead and impl &mut OctetsWrite  and remove code duplication
