### PR TITLE
Nonce backend

### DIFF
--- a/quiceh/src/crypto/boringssl_or_aws.rs
+++ b/quiceh/src/crypto/boringssl_or_aws.rs
@@ -214,6 +214,7 @@ impl PacketKey {
 
         // Make sure it fits in the buffer.
         if !scatter_crypt && in_len + tag_len > buf.len() {
+            debug!("Buffer too small");
             return Err(Error::CryptoFail);
         }
 
@@ -244,6 +245,7 @@ impl PacketKey {
             )
         };
         if rc != 1 {
+            debug!("seal_scatter returned -1");
             return Err(Error::CryptoFail);
         }
 

--- a/quiceh/src/crypto/boringssl_or_aws.rs
+++ b/quiceh/src/crypto/boringssl_or_aws.rs
@@ -28,8 +28,8 @@ pub(crate) struct AES_KEY {
 impl Algorithm {
     fn get_evp_aead(self) -> *const EVP_AEAD {
         match self {
-            Algorithm::AES128_GCM => unsafe { EVP_aead_aes_128_gcm_tls13() },
-            Algorithm::AES256_GCM => unsafe { EVP_aead_aes_256_gcm_tls13() },
+            Algorithm::AES128_GCM => unsafe { EVP_aead_aes_128_gcm() },
+            Algorithm::AES256_GCM => unsafe { EVP_aead_aes_256_gcm() },
             Algorithm::ChaCha20_Poly1305 => unsafe {
                 EVP_aead_chacha20_poly1305()
             },
@@ -390,14 +390,14 @@ use boring_sys as sys;
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD {
-    sys::EVP_aead_aes_128_gcm_tls13() as _
+unsafe fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD {
+    sys::EVP_aead_aes_128_gcm() as _
 }
 
 #[inline]
 #[allow(non_snake_case)]
-unsafe fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD {
-    sys::EVP_aead_aes_256_gcm_tls13() as _
+unsafe fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD {
+    sys::EVP_aead_aes_256_gcm() as _
 }
 
 #[inline]


### PR DESCRIPTION
using ..._gcm_tls13() constrains nonce input to start at 0 and be monotonic. Given the current code, upon key update (hence a change of crypto context), the pn (hence the nonce) would not be changed to 0, and thus returning an error on encryption.

It is safe to not use the _tls() variant as long as we are sure that nonce never repeat. The pn number is currently a monotonic increasing integer.

Note: we should probably be adding a key-update packet test where we encrypt back something after the update.